### PR TITLE
Liquid-glass nav pill: refractive lens + dev tuner

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -170,34 +170,42 @@ const isDev = import.meta.env.DEV;
         <label>
           <span>SQUIRCLE_CLAMP <output data-out="clamp">0.97</output></span>
           <input type="range" min="0.85" max="0.995" step="0.005" value="0.97" data-tune="clamp" />
+          <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
         <label>
           <span>Chromatic R scale <output data-out="scaleR">9</output></span>
           <input type="range" min="0" max="30" step="1" value="9" data-tune="scaleR" />
+          <small class="nav-tuner__hint">How far red light is pulled at the rim.</small>
         </label>
         <label>
           <span>Chromatic G scale <output data-out="scaleG">11</output></span>
           <input type="range" min="0" max="30" step="1" value="11" data-tune="scaleG" />
+          <small class="nav-tuner__hint">How far green light is pulled at the rim.</small>
         </label>
         <label>
           <span>Chromatic B scale <output data-out="scaleB">13</output></span>
           <input type="range" min="0" max="30" step="1" value="13" data-tune="scaleB" />
+          <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens. Bigger numbers = stronger lens overall.</small>
         </label>
         <label>
           <span>Map blur (stdDeviation) <output data-out="mapBlur">0.6</output></span>
           <input type="range" min="0" max="2" step="0.05" value="0.6" data-tune="mapBlur" />
+          <small class="nav-tuner__hint">Smooths the lens curve so the rim doesn't show stair-steps. A little goes a long way.</small>
         </label>
         <label>
           <span>Backdrop blur <output data-out="backdropBlur">1</output>px</span>
           <input type="range" min="0" max="10" step="0.25" value="1" data-tune="backdropBlur" />
+          <small class="nav-tuner__hint">Frosts the background behind the pill. 0 = sharp; higher = misty. Heavy blur smears the rainbow halo.</small>
         </label>
         <label>
           <span>Backdrop saturate <output data-out="saturate">180</output>%</span>
           <input type="range" min="50" max="300" step="5" value="180" data-tune="saturate" />
+          <small class="nav-tuner__hint">Color punch on whatever's behind the pill. 100% = unchanged; higher = punchier.</small>
         </label>
         <label>
           <span>Sheen top alpha <output data-out="sheen">0.30</output></span>
           <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
+          <small class="nav-tuner__hint">Brightness of the white glint along the top edge — the "light hitting glass" highlight.</small>
         </label>
 
         <textarea id="nav-tuner-output" readonly rows="7"></textarea>
@@ -265,6 +273,13 @@ const isDev = import.meta.env.DEV;
       .nav-tuner input[type="range"] {
         width: 100%;
         accent-color: #9be8a3;
+      }
+      .nav-tuner__hint {
+        display: block;
+        font-size: 10.5px;
+        line-height: 1.4;
+        opacity: 0.55;
+        margin-top: 1px;
       }
       .nav-tuner textarea {
         width: 100%;

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -7,169 +7,287 @@ const isDev = import.meta.env.DEV;
 
 <svg class="liquid-glass-defs" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" color-interpolation-filters="sRGB">
   <!--
-    Single-pass liquid glass, ported from the Option E mechanism of
-    themagicianscode.dev/prototypes/liquid-glass-pill: one
-    feDisplacementMap (driven by the canvas-generated 2D displacement
-    map) followed by a heavy feColorMatrix saturate to punch any
-    refracted color through the now-transparent glass. No explicit
-    chromatic-aberration chain — the rainbow fringe at the rim is
-    replaced by amplified color saturation across the displaced
-    backdrop. Chromium-only (Safari/Firefox don't chain SVG filters
-    into backdrop-filter; they fall back to plain blur+saturate).
+    Liquid-glass filter ported from
+    github.com/The-Magicians-Code/prototypes/liquid-glass-pill.
+    Technique by Chris Feijoo (kube.io/blog/liquid-glass-css-svg);
+    implementation original.
 
     Pipeline:
-      1. feImage loads the runtime-generated 2D lens displacement map.
-      2. feGaussianBlur smooths the map to kill stepping artifacts.
-      3. feDisplacementMap warps the backdrop in 2D (R = dx, G = dy).
-      4. feColorMatrix type=saturate punches the color of the result.
+      1. feGaussianBlur softens the SourceGraphic (the backdrop) before
+         the lens warps it — masks sub-pixel artifacts.
+      2. feImage loads the runtime-generated displacement map (Snell's-
+         law refraction profile rasterized to a PNG by the IIFE below).
+      3. feDisplacementMap warps the blurred backdrop. scale set live
+         to the computed maxDisp from the refraction profile.
+      4. feColorMatrix saturate punches refracted color so it reads
+         vivid through the very-transparent panel.
+      5. feImage loads the runtime-generated specular highlight map.
+      6. feComposite operator=in masks the saturated lens output to the
+         shape of the specular highlight (bright rim pixels keep color
+         from the displaced output).
+      7. feComponentTransfer fades the raw specular layer to alpha 0.4
+         so the overlaid highlight doesn't blow out the rim entirely.
+      8-9. Two feBlend passes recombine spec_masked + displaced + spec_faded.
   -->
-  <filter id="liquid-glass-distort" color-interpolation-filters="sRGB"
-          x="0" y="0" width="100%" height="100%">
-    <feImage id="liquid-glass-map" href="" preserveAspectRatio="none" result="rawMap" />
-    <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
-
+  <filter id="liquid-glass-distort" x="0%" y="0%" width="100%" height="100%" color-interpolation-filters="sRGB">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="1.5" result="blurred_source" />
+    <feImage id="liquid-glass-map" href="" result="disp_map" />
     <feDisplacementMap id="liquid-glass-disp"
-                       color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="12"
+                       in="blurred_source" in2="disp_map" scale="0"
                        xChannelSelector="R" yChannelSelector="G" result="displaced" />
-
     <feColorMatrix id="liquid-glass-saturate"
-                   in="displaced" type="saturate" values="4" />
+                   in="displaced" type="saturate" values="4" result="displaced_sat" />
+    <feImage id="liquid-glass-spec" href="" result="spec_layer" />
+    <feComposite in="displaced_sat" in2="spec_layer" operator="in" result="spec_masked" />
+    <feComponentTransfer in="spec_layer" result="spec_faded">
+      <feFuncA id="liquid-glass-spec-alpha" type="linear" slope="0.4" />
+    </feComponentTransfer>
+    <feBlend in="spec_masked" in2="displaced" mode="normal" result="with_sat" />
+    <feBlend in="spec_faded" in2="with_sat" mode="normal" />
   </filter>
 </svg>
 
 <script is:inline>
-  // 2D pill-shape displacement map, generated at the actual pill dimensions
-  // and re-generated when the pill resizes. Encodes both X (R channel) and
-  // Y (G channel) displacement so the rounded corners wrap content from
-  // the opposite side of the pill — the corner-wrap effect Apple's pills
-  // exhibit, that pure cylindrical (Y-only) refraction cannot reproduce.
+  // Liquid-glass IIFE — physics + maps ported from
+  // github.com/The-Magicians-Code/prototypes/liquid-glass-pill (pill.js).
   //
-  // Per pixel, the shape is decomposed into:
-  //   - Central flat section: pure vertical refraction (cylindrical lens)
-  //   - Two rounded ends:     radial refraction toward the corner center
-  // Pixels outside the pill rim (corners of the rectangular canvas not
-  // covered by the rounded shape) encode no displacement (R=G=128).
+  // Algorithm overview:
+  //   - heightAt(t):              convex squircle bezel surface profile
+  //   - refractRay(nx,ny,ior):    Snell's law for a downward incident ray
+  //   - buildRefractionProfile(): traces refracted rays at each radial
+  //                               sample → 1D Float64 array of lateral
+  //                               displacements (px) at each bezel position
+  //   - generateDisplacementMap(): rasterizes the profile + uniform-slab
+  //                               shift into an R/G PNG for feDisplacementMap
+  //   - generateSpecularMap():    rasterizes a directional rim-light into
+  //                               a grayscale PNG for the specular feImage
   //
-  // Squircle profile from kube.io/blog/liquid-glass-css-svg: refraction
-  // magnitude follows |dy/dx| = t³ / (1 − t⁴)^¾ where t is normalized
-  // distance from center toward the nearest rim point. Clamped before
-  // the singularity at t=1, normalized so the clamp value maps to 1.0.
+  // Tunables read from CSS custom properties on :root via getComputedStyle:
+  //   --lg-thickness, --lg-bezel, --lg-ior, --lg-uniform-shift
+  // The dev tuner mutates these vars and re-runs init().
   (function () {
-    let SQUIRCLE_CLAMP = 0.97;
+    'use strict';
 
-    function squircleSlope(t) {
-      const tc = Math.min(t, SQUIRCLE_CLAMP);
-      return Math.pow(tc, 3) / Math.pow(1 - Math.pow(tc, 4), 0.75);
+    function heightAt(t) {
+      return Math.pow(1 - Math.pow(1 - t, 4), 0.25);
     }
 
-    function generateLensMap(W, H) {
+    function refractRay(nx, ny, ior) {
+      const eta = 1 / ior;
+      const dot = ny;
+      const k = 1 - eta * eta * (1 - dot * dot);
+      if (k < 0) return null;
+      const sq = Math.sqrt(k);
+      return [-(eta * dot + sq) * nx, eta - (eta * dot + sq) * ny];
+    }
+
+    function buildRefractionProfile(thickness, bezelWidth, ior, samples) {
+      samples = samples || 128;
+      const profile = new Float64Array(samples);
+      for (let i = 0; i < samples; i++) {
+        const t = i / samples;
+        const y = heightAt(t);
+        const dt = t < 1 ? 0.0001 : -0.0001;
+        const y2 = heightAt(t + dt);
+        const deriv = (y2 - y) / dt;
+        const mag = Math.sqrt(deriv * deriv + 1);
+        const nx = -deriv / mag;
+        const ny = -1 / mag;
+        const ref = refractRay(nx, ny, ior);
+        if (!ref) { profile[i] = 0; continue; }
+        profile[i] = ref[0] * ((y * bezelWidth + thickness) / ref[1]);
+      }
+      return profile;
+    }
+
+    function generateDisplacementMap(w, h, radius, bezelWidth, profile, maxDisp, uniformShiftPx) {
       const canvas = document.createElement('canvas');
-      canvas.width = W;
-      canvas.height = H;
+      canvas.width = w; canvas.height = h;
       const ctx = canvas.getContext('2d');
-      const img = ctx.createImageData(W, H);
+      const img = ctx.createImageData(w, h);
       const data = img.data;
 
-      const Wh = W / 2;
-      const Hh = H / 2;
-      const radius = Hh; // full-radius pill (border-radius: 999px)
-      const flatHalfW = Math.max(0, Wh - Hh); // length of central flat half
-      const maxSlope = squircleSlope(SQUIRCLE_CLAMP);
+      const r = radius;
+      const rSq = r * r;
+      const r1Sq = (r + 1) * (r + 1);
+      const rBSq = Math.max(r - bezelWidth, 0) * Math.max(r - bezelWidth, 0);
+      const wB = w - r * 2;
+      const hB = h - r * 2;
+      const samples = profile.length;
+      const uniformR = -((uniformShiftPx || 0) / maxDisp) * 255;
 
-      for (let y = 0; y < H; y++) {
-        for (let x = 0; x < W; x++) {
-          // Pixel-center coords relative to pill center
-          const px = x + 0.5 - Wh;
-          const py = y + 0.5 - Hh;
+      // Phase 1 — uniform slab fill inside pill, neutral outside
+      for (let py = 0; py < h; py++) {
+        for (let px = 0; px < w; px++) {
+          const cx = px + 0.5, cy = py + 0.5;
+          const x = cx < r ? cx - r : (cx >= w - r ? cx - r - wB : 0);
+          const y = cy < r ? cy - r : (cy >= h - r ? cy - r - hB : 0);
+          const dSq = x * x + y * y;
+          const idx = (py * w + px) * 4;
+          const insidePill = dSq <= rSq;
+          data[idx] = 128 + (insidePill ? Math.round(uniformR) : 0);
+          data[idx + 1] = 128;
+          data[idx + 2] = 0;
+          data[idx + 3] = 255;
+        }
+      }
 
-          let d, dirX, dirY;
-
-          if (Math.abs(px) <= flatHalfW) {
-            // Central flat section — Y refraction only (cylindrical)
-            d = radius - Math.abs(py);
-            dirX = 0;
-            dirY = py === 0 ? 0 : -Math.sign(py);
-          } else {
-            // Rounded end — radial refraction toward the corner center
-            const cx = Math.sign(px) * flatHalfW;
-            const dxC = px - cx;
-            const dyC = py;
-            const distFromCorner = Math.sqrt(dxC * dxC + dyC * dyC);
-            d = radius - distFromCorner;
-            if (distFromCorner > 0.001) {
-              dirX = -dxC / distFromCorner;
-              dirY = -dyC / distFromCorner;
-            } else {
-              dirX = 0;
-              dirY = 0;
-            }
-          }
-
-          const i = (y * W + x) * 4;
-
-          if (d < 0) {
-            // Outside the pill rim — encode neutral (no displacement)
-            data[i] = 128;
-            data[i + 1] = 128;
-          } else {
-            const r = 1 - d / radius; // 0 at center, 1 at rim
-            const magnitude = squircleSlope(r) / maxSlope;
-            data[i] = Math.round(128 + dirX * magnitude * 127);
-            data[i + 1] = Math.round(128 + dirY * magnitude * 127);
-          }
-          data[i + 2] = 0;
-          data[i + 3] = 255;
+      // Phase 2 — bezel rim curl combined with the uniform shift
+      for (let py = 0; py < h; py++) {
+        for (let px = 0; px < w; px++) {
+          const cx = px + 0.5, cy = py + 0.5;
+          const x = cx < r ? cx - r : (cx >= w - r ? cx - r - wB : 0);
+          const y = cy < r ? cy - r : (cy >= h - r ? cy - r - hB : 0);
+          const dSq = x * x + y * y;
+          if (dSq > r1Sq || dSq < rBSq) continue;
+          const dist = Math.sqrt(dSq);
+          if (dist === 0) continue;
+          const fromSide = r - dist;
+          const op = dSq < rSq ? 1 : 1 - (dist - Math.sqrt(rSq)) / (Math.sqrt(r1Sq) - Math.sqrt(rSq));
+          if (op <= 0) continue;
+          const t = Math.max(0, Math.min(1, fromSide / bezelWidth));
+          const sampleIdx = Math.min((t * samples) | 0, samples - 1);
+          const disp = profile[sampleIdx] || 0;
+          const dirX = x / dist;
+          const dirY = y / dist;
+          const dX = (-dirX * disp) / maxDisp;
+          const dY = (-dirY * disp) / maxDisp;
+          const baseR = 128 + uniformR * (dSq <= rSq ? 1 : op);
+          const idx = (py * w + px) * 4;
+          data[idx] = Math.max(0, Math.min(255, Math.round(baseR + dX * 127 * op)));
+          data[idx + 1] = Math.max(0, Math.min(255, Math.round(128 + dY * 127 * op)));
         }
       }
 
       ctx.putImageData(img, 0, 0);
-      return canvas.toDataURL('image/png');
+      return canvas.toDataURL();
     }
 
-    function regenerate() {
+    function generateSpecularMap(w, h, radius, bezelWidth, angle) {
+      angle = angle != null ? angle : Math.PI / 2;
+      const canvas = document.createElement('canvas');
+      canvas.width = w; canvas.height = h;
+      const ctx = canvas.getContext('2d');
+      const img = ctx.createImageData(w, h);
+      const data = img.data;
+      data.fill(0);
+
+      const r = radius;
+      const rSq = r * r;
+      const r1Sq = (r + 1) * (r + 1);
+      const rBSq = Math.max(r - bezelWidth, 0) * Math.max(r - bezelWidth, 0);
+      const wB = w - r * 2;
+      const hB = h - r * 2;
+      const lightX = Math.cos(angle);
+      const lightY = Math.sin(angle);
+
+      for (let py = 0; py < h; py++) {
+        for (let px = 0; px < w; px++) {
+          const cx = px + 0.5, cy = py + 0.5;
+          const x = cx < r ? cx - r : (cx >= w - r ? cx - r - wB : 0);
+          const y = cy < r ? cy - r : (cy >= h - r ? cy - r - hB : 0);
+          const dSq = x * x + y * y;
+          if (dSq > r1Sq || dSq < rBSq) continue;
+          const dist = Math.sqrt(dSq);
+          if (dist === 0) continue;
+          const fromSide = r - dist;
+          const op = dSq < rSq ? 1 : 1 - (dist - Math.sqrt(rSq)) / (Math.sqrt(r1Sq) - Math.sqrt(rSq));
+          if (op <= 0) continue;
+          const dirX = x / dist;
+          const dirY = -y / dist;
+          const dot = Math.abs(dirX * lightX + dirY * lightY);
+          const edge = Math.sqrt(Math.max(0, 1 - (1 - fromSide) * (1 - fromSide)));
+          const coeff = dot * edge;
+          const col = (255 * coeff) | 0;
+          const alpha = (255 * coeff * coeff * op) | 0;
+          const idx = (py * w + px) * 4;
+          data[idx] = col;
+          data[idx + 1] = col;
+          data[idx + 2] = col;
+          data[idx + 3] = alpha;
+        }
+      }
+      ctx.putImageData(img, 0, 0);
+      return canvas.toDataURL();
+    }
+
+    function readCssNumber(el, prop, fallback) {
+      const raw = getComputedStyle(el).getPropertyValue(prop).trim();
+      const v = parseFloat(raw);
+      return Number.isFinite(v) ? v : fallback;
+    }
+
+    function init() {
       const pill = document.getElementById('nav-pill');
-      const feImg = document.getElementById('liquid-glass-map');
-      if (!pill || !feImg) return;
-      const rect = pill.getBoundingClientRect();
-      const W = Math.round(rect.width);
-      const H = Math.round(rect.height);
-      if (W <= 0 || H <= 0) return;
-      const url = generateLensMap(W, H);
-      feImg.setAttribute('href', url);
-      feImg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', url);
+      if (!pill) return;
+      try {
+        const rect = pill.getBoundingClientRect();
+        const w = Math.round(rect.width);
+        const h = Math.round(rect.height);
+        if (w <= 0 || h <= 0) return;
+        const radius = Math.min(parseFloat(getComputedStyle(pill).borderRadius) || h / 2, h / 2);
+
+        const root = document.documentElement;
+        const thickness = readCssNumber(root, '--lg-thickness', 80);
+        const bezelWidth = readCssNumber(root, '--lg-bezel', 20);
+        const ior = readCssNumber(root, '--lg-ior', 1.5);
+        const uniformShift = readCssNumber(root, '--lg-uniform-shift', 0);
+        const samples = 128;
+
+        const clampedBezel = Math.min(bezelWidth, radius - 1, Math.min(w, h) / 2 - 1);
+        const profile = buildRefractionProfile(thickness, clampedBezel, ior, samples);
+        const maxRimDisp = Math.max.apply(null, Array.from(profile).map(Math.abs)) || 1;
+        const maxDisp = (maxRimDisp + 2 * Math.abs(uniformShift)) || 1;
+
+        const dispUrl = generateDisplacementMap(w, h, radius, clampedBezel, profile, maxDisp, uniformShift);
+        const dispEl = document.getElementById('liquid-glass-map');
+        if (dispEl) {
+          dispEl.setAttribute('href', dispUrl);
+          dispEl.setAttributeNS('http://www.w3.org/1999/xlink', 'href', dispUrl);
+          dispEl.setAttribute('width', String(w));
+          dispEl.setAttribute('height', String(h));
+        }
+        const dispMapEl = document.getElementById('liquid-glass-disp');
+        if (dispMapEl) dispMapEl.setAttribute('scale', String(maxDisp));
+
+        const specBezel = clampedBezel * 2.5;
+        const specUrl = generateSpecularMap(w, h, radius, specBezel, Math.PI / 2);
+        const specEl = document.getElementById('liquid-glass-spec');
+        if (specEl) {
+          specEl.setAttribute('href', specUrl);
+          specEl.setAttributeNS('http://www.w3.org/1999/xlink', 'href', specUrl);
+          specEl.setAttribute('width', String(w));
+          specEl.setAttribute('height', String(h));
+        }
+
+        window.__lgPill = { heightAt, refractRay, buildRefractionProfile, generateDisplacementMap, generateSpecularMap, init };
+      } catch (err) {
+        console.warn('liquid-glass-pill: filter generation failed; frosted-glass fallback remains active.', err);
+      }
     }
 
-    let resizeTimer;
+    let resizeTimer = null;
     let resizeObserver;
     function observePill() {
       const pill = document.getElementById('nav-pill');
       if (!pill || resizeObserver) return;
       resizeObserver = new ResizeObserver(() => {
         clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(regenerate, 80);
+        resizeTimer = setTimeout(init, 100);
       });
       resizeObserver.observe(pill);
     }
 
-    function init() {
-      regenerate();
-      observePill();
-    }
+    function start() { init(); observePill(); }
 
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', init);
+      document.addEventListener('DOMContentLoaded', start);
     } else {
-      init();
+      start();
     }
 
-    // Dev tuner hook — listens for clamp updates from NavTuner and regenerates.
-    window.addEventListener('navlens:setClamp', (e) => {
-      if (e.detail && typeof e.detail.value === 'number') {
-        SQUIRCLE_CLAMP = e.detail.value;
-        regenerate();
-      }
-    });
+    // Dev tuner hook — re-init when CSS variable inputs change.
+    window.addEventListener('navlens:reinit', init);
   })();
 </script>
 
@@ -228,36 +346,30 @@ const isDev = import.meta.env.DEV;
           <button type="button" role="tab" data-mode="advanced" aria-selected="false">Advanced</button>
         </div>
 
-        <label data-mode="simple">
-          <span>Refraction Level <output data-out="refractionLevel">1.00</output></span>
-          <input type="range" min="0" max="2" step="0.05" value="1.00" data-tune="refractionLevel" />
-          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock (Apple-subtle); 0 = no bend; 2 = exaggerated. Inversion-safe across the whole slider range at the current scale.</small>
+        <label data-mode="both">
+          <span>Glass Thickness <output data-out="thickness">80</output></span>
+          <input type="range" min="10" max="200" step="5" value="80" data-tune="thickness" />
+          <small class="nav-tuner__hint">How thick the glass slab is, in px. Bigger = light travels further through the glass = stronger Snell's-law bend at the rim. Drives the --lg-thickness CSS var.</small>
         </label>
         <label data-mode="both">
           <span>Color Punch <output data-out="internalSat">4</output></span>
           <input type="range" min="0" max="10" step="0.25" value="4" data-tune="internalSat" />
-          <small class="nav-tuner__hint">How vivid the refracted backdrop reads through the glass. 0 = grayscale (no color); 1 = unchanged; 4 = strong (Apple-style); higher = oversaturated. Applied as feColorMatrix saturate inside the filter, the prototype's actual mechanism.</small>
-        </label>
-
-        <label data-mode="both">
-          <span>Specular Opacity <output data-out="sheen">0.30</output></span>
-          <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
-          <small class="nav-tuner__hint">Brightness of the white glint along the top edge — the "light hitting glass" highlight.</small>
+          <small class="nav-tuner__hint">How vivid the refracted backdrop reads through the glass. 0 = grayscale; 1 = unchanged; 4 = strong (Apple-style). Drives feColorMatrix saturate inside the filter.</small>
         </label>
         <label data-mode="both">
-          <span>Specular Saturation <output data-out="specularSat">2.5</output></span>
-          <input type="range" min="0" max="10" step="0.1" value="2.5" data-tune="specularSat" />
-          <small class="nav-tuner__hint">How vivid the highlight's tint is. 0 = pure grayscale; 1 = neutral; higher = picks up subtle warm/cool color in the glint.</small>
+          <span>Specular Strength <output data-out="specStrength">0.4</output></span>
+          <input type="range" min="0" max="1" step="0.05" value="0.4" data-tune="specStrength" />
+          <small class="nav-tuner__hint">Brightness of the SVG-rendered rim highlight. Drives the feFuncA slope on the specular layer. 0 = no highlight, 1 = full strength.</small>
         </label>
         <label data-mode="both">
           <span>Blur Level <output data-out="backdropBlur">7</output>px</span>
-          <input type="range" min="0" max="10" step="0.25" value="7" data-tune="backdropBlur" />
-          <small class="nav-tuner__hint">Frosts the background behind the pill. 0 = sharp; higher = misty. Heavy blur smears the rainbow halo.</small>
+          <input type="range" min="0" max="20" step="0.25" value="7" data-tune="backdropBlur" />
+          <small class="nav-tuner__hint">Frosts the backdrop behind the pill. CSS backdrop-filter blur, applied before the SVG lens.</small>
         </label>
         <label data-mode="both">
           <span>Progressive Blur <output data-out="progBlur">0.5</output>px</span>
           <input type="range" min="0" max="15" step="0.5" value="0.5" data-tune="progBlur" />
-          <small class="nav-tuner__hint">Gradient blur across the top of the page that fades to clear lower down. Softens the area where content scrolls under the nav.</small>
+          <small class="nav-tuner__hint">Gradient blur on the strip above where content scrolls under the nav. Softens the transition into the pill.</small>
         </label>
         <label data-mode="both">
           <span>Glass BG Opacity <output data-out="glassBg">0.06</output></span>
@@ -266,24 +378,24 @@ const isDev = import.meta.env.DEV;
         </label>
 
         <label data-mode="advanced">
-          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.97</output></span>
-          <input type="range" min="0.85" max="0.995" step="0.005" value="0.97" data-tune="clamp" />
-          <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
+          <span>Bezel Width <output data-out="bezel">20</output>px</span>
+          <input type="range" min="2" max="50" step="1" value="20" data-tune="bezel" />
+          <small class="nav-tuner__hint">Width of the curved bezel band at the rim. Wider = the rim curl extends further into the body. Drives --lg-bezel.</small>
         </label>
         <label data-mode="advanced">
-          <span>Refraction Scale <output data-out="scale">12</output></span>
-          <input type="range" min="0" max="60" step="1" value="12" data-tune="scale" />
-          <small class="nav-tuner__hint">Pixel displacement at the rim — the absolute scale on feDisplacementMap. Refraction Level multiplies BASE_CENTER (=12) to derive this; tweak directly to override.</small>
+          <span>IOR <output data-out="ior">1.5</output></span>
+          <input type="range" min="1" max="2.5" step="0.05" value="1.5" data-tune="ior" />
+          <small class="nav-tuner__hint">Refractive index. 1.0 = no refraction (air); 1.5 = standard glass; 2.4 = diamond. Higher = stronger Snell's-law bend. Drives --lg-ior.</small>
         </label>
         <label data-mode="advanced">
-          <span>Map blur (stdDeviation) <output data-out="mapBlur">1.4</output></span>
-          <input type="range" min="0" max="2" step="0.05" value="1.4" data-tune="mapBlur" />
-          <small class="nav-tuner__hint">Smooths the lens curve so the rim doesn't show stair-steps. A little goes a long way.</small>
+          <span>Uniform Shift <output data-out="uniformShift">0</output>px</span>
+          <input type="range" min="-10" max="10" step="0.5" value="0" data-tune="uniformShift" />
+          <small class="nav-tuner__hint">Apple-style tilted-slab refraction across the whole pill, on top of the rim curl. 0 = pure rim curl; ±5–10 = visible directional drift. Drives --lg-uniform-shift.</small>
         </label>
         <label data-mode="advanced">
           <span>Backdrop saturate (pre-filter) <output data-out="saturate">100</output>%</span>
           <input type="range" min="50" max="500" step="5" value="100" data-tune="saturate" />
-          <small class="nav-tuner__hint">Saturation applied by CSS backdrop-filter <em>before</em> the SVG sees the backdrop. Stacks multiplicatively with Color Punch. 100% = no extra punch.</small>
+          <small class="nav-tuner__hint">CSS backdrop-filter saturate, applied before the SVG sees the backdrop. Stacks with Color Punch. 100% = no extra punch.</small>
         </label>
 
         <textarea id="nav-tuner-output" readonly rows="10"></textarea>
@@ -440,85 +552,75 @@ const isDev = import.meta.env.DEV;
 
     <script is:inline>
       (function () {
-        // Base chromatic model — Refraction Level (simplified) scales BASE_CENTER,
-        // Chromatic Spread (simplified) is the ±offset of R and B from the center.
-        // Defaults: center=12, spread=2 → 10/12/14 (Apple-stock subtle: ~6px rim
-        // displacement on the 64px pill, well below the ~32 inversion threshold
-        // across the full 0–2 slider range).
-        const BASE_CENTER = 12;
+        // CSS variable inputs the IIFE reads via getComputedStyle; mutating
+        // these from the tuner + dispatching navlens:reinit re-runs init().
+        const CSS_VAR_BY_KEY = {
+          thickness: '--lg-thickness',
+          bezel: '--lg-bezel',
+          ior: '--lg-ior',
+          uniformShift: '--lg-uniform-shift',
+        };
+        const REINIT_KEYS = new Set(Object.keys(CSS_VAR_BY_KEY));
+
+        // Debounce reinit since dragging fires input events many times per second.
+        let reinitScheduled = false;
+        function scheduleReinit() {
+          if (reinitScheduled) return;
+          reinitScheduled = true;
+          requestAnimationFrame(() => {
+            reinitScheduled = false;
+            window.dispatchEvent(new Event('navlens:reinit'));
+          });
+        }
 
         function setup() {
           const panel = document.getElementById('nav-tuner-panel');
           if (!panel) return;
 
-          const disp = document.getElementById('liquid-glass-disp');
           const satMatrix = document.getElementById('liquid-glass-saturate');
-          const mapBlurEl = document.querySelector('#liquid-glass-distort feGaussianBlur');
+          const specAlpha = document.getElementById('liquid-glass-spec-alpha');
           const progLayer = document.querySelector('.nav-progressive-blur');
 
-          // Inline override <style> for things JS can't hit directly
-          // (::before pseudo + !important needed to beat the stylesheet rule).
           const overrideStyle = document.createElement('style');
           overrideStyle.id = 'nav-tuner-overrides';
           document.head.appendChild(overrideStyle);
 
           const defaults = {
-            // Advanced underlying state
-            clamp: 0.97,
-            scale: 12,
-            mapBlur: 1.4,
-            saturate: 100,            // CSS backdrop-filter saturate (pre-SVG)
-            // Both-mode state
-            sheen: 0.30,
-            specularSat: 2.5,
+            // Refraction physics — mutate CSS vars + reinit
+            thickness: 80,
+            bezel: 20,
+            ior: 1.5,
+            uniformShift: 0,
+            // SVG-side knobs — direct attribute set
+            internalSat: 4,
+            specStrength: 0.4,
+            // CSS-side knobs — override style
             backdropBlur: 7,
-            progBlur: 0.5,
+            saturate: 100,
             glassBg: 0.06,
-            internalSat: 4,           // feColorMatrix saturate (post-displacement)
-            // Simplified-mode derived view: scale = BASE_CENTER * refractionLevel
-            refractionLevel: 1.00,
+            progBlur: 0.5,
           };
           const state = { ...defaults };
 
-          // Per-key display formatter — keeps the value chip compact and readable.
           function fmtDisplay(key, v) {
-            if (key === 'clamp') {
-              return v.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
-            }
-            if (
-              key === 'mapBlur' || key === 'sheen' || key === 'glassBg' ||
-              key === 'refractionLevel' || key === 'specularSat' ||
-              key === 'internalSat'
-            ) {
+            if (key === 'ior' || key === 'specStrength' || key === 'glassBg' || key === 'internalSat') {
               return v.toFixed(2);
             }
             return String(v);
           }
 
-          function applySimpleToScale() {
-            state.scale = Math.round(BASE_CENTER * state.refractionLevel);
-          }
-
-          function deriveSimpleFromScale() {
-            state.refractionLevel = Math.max(0, Math.min(2, state.scale / BASE_CENTER));
-          }
-
           function apply() {
-            // SVG primitives: single displacement scale + map blur + internal saturate
-            disp.setAttribute('scale', state.scale);
-            mapBlurEl.setAttribute('stdDeviation', state.mapBlur);
-            satMatrix.setAttribute('values', state.internalSat);
+            // SVG attributes — direct
+            satMatrix.setAttribute('values', String(state.internalSat));
+            specAlpha.setAttribute('slope', String(state.specStrength));
 
-            // Progressive-blur strip — inline backdrop-filter
+            // Progressive-blur strip
             if (progLayer) {
               progLayer.style.webkitBackdropFilter = `blur(${state.progBlur}px)`;
               progLayer.style.backdropFilter = `blur(${state.progBlur}px)`;
             }
 
-            // Sheen now uses faint warm-pink top + cool-blue mid stops so
-            // filter: saturate(N) on ::before has actual hue to act on. At
-            // saturate(0) the result reads as pure white; at saturate(>1) the
-            // tints become visible as a subtle iridescence.
+            // CSS overrides
             overrideStyle.textContent = `
               @media (min-width: 641px) {
                 #nav-pill {
@@ -529,24 +631,6 @@ const isDev = import.meta.env.DEV;
                 html.dark #nav-pill {
                   background: rgba(23, 23, 23, ${state.glassBg}) !important;
                 }
-                #nav-pill::before {
-                  background: linear-gradient(
-                    180deg,
-                    rgba(255, 240, 245, ${state.sheen}) 0%,
-                    rgba(220, 235, 255, ${(state.sheen * 0.2).toFixed(3)}) 40%,
-                    transparent 70%
-                  ) !important;
-                  filter: saturate(${state.specularSat}) !important;
-                }
-                html.dark #nav-pill::before {
-                  background: linear-gradient(
-                    180deg,
-                    rgba(255, 240, 245, ${(state.sheen * 0.53).toFixed(3)}) 0%,
-                    rgba(220, 235, 255, ${(state.sheen * 0.1).toFixed(3)}) 40%,
-                    transparent 70%
-                  ) !important;
-                  filter: saturate(${state.specularSat}) !important;
-                }
               }
             `;
 
@@ -555,37 +639,33 @@ const isDev = import.meta.env.DEV;
 
           function formatValues(s) {
             return [
-              `SQUIRCLE_CLAMP=${fmtDisplay('clamp', s.clamp)}`,
-              `RefractionScale=${s.scale}`,
-              `InternalSaturate=${fmtDisplay('internalSat', s.internalSat)}`,
-              `MapBlur=${s.mapBlur}`,
+              `Thickness=${s.thickness}`,
+              `Bezel=${s.bezel}`,
+              `IOR=${fmtDisplay('ior', s.ior)}`,
+              `UniformShift=${s.uniformShift}`,
+              `ColorPunch=${fmtDisplay('internalSat', s.internalSat)}`,
+              `Specular=${fmtDisplay('specStrength', s.specStrength)}`,
               `BackdropBlur=${s.backdropBlur}px`,
               `BackdropSaturate=${s.saturate}%`,
-              `SheenTop=${s.sheen}`,
-              `SpecularSaturation=${s.specularSat}`,
+              `GlassBgOpacity=${fmtDisplay('glassBg', s.glassBg)}`,
               `ProgressiveBlur=${s.progBlur}px`,
-              `GlassBgOpacity=${s.glassBg}`,
             ].join('\n');
           }
 
-          let regenScheduled = false;
-          function scheduleRegen() {
-            if (regenScheduled) return;
-            regenScheduled = true;
-            requestAnimationFrame(() => {
-              regenScheduled = false;
-              window.dispatchEvent(new CustomEvent('navlens:setClamp', {
-                detail: { value: state.clamp }
-              }));
-            });
-          }
-
-          // Sync a single slider's input value + output chip to current state.
           function syncControl(key) {
             const input = panel.querySelector(`input[data-tune="${key}"]`);
             const out = panel.querySelector(`output[data-out="${key}"]`);
             if (input) input.value = state[key];
             if (out) out.textContent = fmtDisplay(key, state[key]);
+          }
+
+          // Push the current refraction-physics state into the CSS variables
+          // the IIFE reads. Used at first paint and on Reset.
+          function pushCssVars() {
+            const root = document.documentElement;
+            Object.keys(CSS_VAR_BY_KEY).forEach((key) => {
+              root.style.setProperty(CSS_VAR_BY_KEY[key], String(state[key]));
+            });
           }
 
           panel.querySelectorAll('input[type="range"]').forEach((input) => {
@@ -596,25 +676,15 @@ const isDev = import.meta.env.DEV;
               const out = panel.querySelector(`output[data-out="${key}"]`);
               if (out) out.textContent = fmtDisplay(key, v);
 
-              if (key === 'clamp') scheduleRegen();
-
-              // Refraction Level (simplified) → derive single scale
-              if (key === 'refractionLevel') {
-                applySimpleToScale();
-                syncControl('scale');
-              }
-              // Refraction Scale (advanced) → derive Refraction Level so
-              // toggling to Simplified shows a value consistent with state.
-              if (key === 'scale') {
-                deriveSimpleFromScale();
-                syncControl('refractionLevel');
+              if (REINIT_KEYS.has(key)) {
+                document.documentElement.style.setProperty(CSS_VAR_BY_KEY[key], String(v));
+                scheduleReinit();
               }
 
               apply();
             });
           });
 
-          // Mode toggle
           panel.querySelectorAll('.nav-tuner__mode-toggle button').forEach((btn) => {
             btn.addEventListener('click', () => {
               const mode = btn.dataset.mode;
@@ -625,12 +695,6 @@ const isDev = import.meta.env.DEV;
                 b.classList.toggle('active', active);
                 b.setAttribute('aria-selected', String(active));
               });
-              // Re-derive Refraction Level when entering Simplified, in case
-              // advanced edits drifted scale away from BASE_CENTER × level.
-              if (mode === 'simple') {
-                deriveSimpleFromScale();
-                syncControl('refractionLevel');
-              }
             });
           });
 
@@ -652,7 +716,8 @@ const isDev = import.meta.env.DEV;
             panel.querySelectorAll('input[type="range"]').forEach((input) => {
               syncControl(input.dataset.tune);
             });
-            scheduleRegen();
+            pushCssVars();
+            scheduleReinit();
             apply();
           });
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -362,8 +362,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Brightness of the SVG-rendered rim highlight. Drives the feFuncA slope on the specular layer. 0 = no highlight, 1 = full strength.</small>
         </label>
         <label data-mode="both">
-          <span>Blur Level <output data-out="backdropBlur">7</output>px</span>
-          <input type="range" min="0" max="20" step="0.25" value="7" data-tune="backdropBlur" />
+          <span>Blur Level <output data-out="backdropBlur">4</output>px</span>
+          <input type="range" min="0" max="20" step="0.25" value="4" data-tune="backdropBlur" />
           <small class="nav-tuner__hint">Frosts the backdrop behind the pill. CSS backdrop-filter blur, applied before the SVG lens.</small>
         </label>
         <label data-mode="both">
@@ -388,8 +388,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Refractive index. 1.0 = no refraction (air); 1.5 = standard glass; 2.4 = diamond. Higher = stronger Snell's-law bend. Drives --lg-ior.</small>
         </label>
         <label data-mode="advanced">
-          <span>Uniform Shift <output data-out="uniformShift">0</output>px</span>
-          <input type="range" min="-10" max="10" step="0.5" value="0" data-tune="uniformShift" />
+          <span>Uniform Shift <output data-out="uniformShift">-4.5</output>px</span>
+          <input type="range" min="-10" max="10" step="0.5" value="-4.5" data-tune="uniformShift" />
           <small class="nav-tuner__hint">Apple-style tilted-slab refraction across the whole pill, on top of the rim curl. 0 = pure rim curl; ±5–10 = visible directional drift. Drives --lg-uniform-shift.</small>
         </label>
         <label data-mode="advanced">
@@ -590,12 +590,12 @@ const isDev = import.meta.env.DEV;
             thickness: 80,
             bezel: 20,
             ior: 1.5,
-            uniformShift: 0,
+            uniformShift: -4.5,
             // SVG-side knobs — direct attribute set
             internalSat: 4,
             specStrength: 0.4,
             // CSS-side knobs — override style
-            backdropBlur: 7,
+            backdropBlur: 4,
             saturate: 100,
             glassBg: 0.06,
             progBlur: 0.5,

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -20,15 +20,19 @@ const isDev = import.meta.env.DEV;
       4. feColorMatrix isolates each channel so we don't double-count.
       5. feBlend mode="lighten" recombines (per-channel max).
   -->
-  <filter id="liquid-glass-distort" x="0" y="0" width="100%" height="100%">
+  <filter id="liquid-glass-distort" color-interpolation-filters="sRGB"
+          x="0" y="0" width="100%" height="100%">
     <feImage id="liquid-glass-map" href="" preserveAspectRatio="none" result="rawMap" />
     <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
 
-    <feDisplacementMap in="SourceGraphic" in2="map" scale="9"
+    <feDisplacementMap color-interpolation-filters="sRGB"
+                       in="SourceGraphic" in2="map" scale="5"
                        xChannelSelector="R" yChannelSelector="G" result="dispR" />
-    <feDisplacementMap in="SourceGraphic" in2="map" scale="11"
+    <feDisplacementMap color-interpolation-filters="sRGB"
+                       in="SourceGraphic" in2="map" scale="6"
                        xChannelSelector="R" yChannelSelector="G" result="dispG" />
-    <feDisplacementMap in="SourceGraphic" in2="map" scale="13"
+    <feDisplacementMap color-interpolation-filters="sRGB"
+                       in="SourceGraphic" in2="map" scale="7"
                        xChannelSelector="R" yChannelSelector="G" result="dispB" />
 
     <feColorMatrix in="dispR" type="matrix" result="rOnly" values="
@@ -63,7 +67,7 @@ const isDev = import.meta.env.DEV;
     // distance-from-center: |dy/dx| = t³ / (1 − t⁴)^¾. Slope diverges at the
     // rim, so clamp t before the singularity and normalize so the clamped
     // peak maps to 1.
-    let SQUIRCLE_CLAMP = 0.97;
+    let SQUIRCLE_CLAMP = 0.99;
 
     function generateLensMap() {
       const W = 512;
@@ -161,54 +165,88 @@ const isDev = import.meta.env.DEV;
 
 {isDev && (
   <Fragment>
-    <aside id="nav-tuner-panel" class="nav-tuner" aria-label="Liquid glass tuner">
+    <div class="nav-progressive-blur" aria-hidden="true"></div>
+
+    <aside id="nav-tuner-panel" class="nav-tuner mode-simple" aria-label="Liquid glass tuner">
       <header class="nav-tuner__head">
         <span>Nav glass tuner</span>
         <button type="button" id="nav-tuner-toggle" aria-label="Collapse tuner">−</button>
       </header>
       <div class="nav-tuner__body">
-        <label>
-          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.97</output></span>
-          <input type="range" min="0.85" max="0.995" step="0.005" value="0.97" data-tune="clamp" />
+        <div class="nav-tuner__mode-toggle" role="tablist" aria-label="Tuner mode">
+          <button type="button" role="tab" class="active" data-mode="simple" aria-selected="true">Simplified</button>
+          <button type="button" role="tab" data-mode="advanced" aria-selected="false">Advanced</button>
+        </div>
+
+        <label data-mode="simple">
+          <span>Refraction Level <output data-out="refractionLevel">1.00</output></span>
+          <input type="range" min="0" max="2" step="0.05" value="1.00" data-tune="refractionLevel" />
+          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock; 0 = no bend; 2 = exaggerated. Above 2 the lens enters the inversion regime and projects flipped ghost text — capped here. Use Advanced for full control.</small>
+        </label>
+        <label data-mode="simple">
+          <span>Chromatic Spread <output data-out="chromaticSpread">1</output></span>
+          <input type="range" min="0" max="10" step="1" value="1" data-tune="chromaticSpread" />
+          <small class="nav-tuner__hint">Width of the rainbow halo at the rim. 0 = clean lens, no fringe. Higher = stronger color fringing. Independent of overall strength.</small>
+        </label>
+
+        <label data-mode="both">
+          <span>Specular Opacity <output data-out="sheen">0.30</output></span>
+          <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
+          <small class="nav-tuner__hint">Brightness of the white glint along the top edge — the "light hitting glass" highlight.</small>
+        </label>
+        <label data-mode="both">
+          <span>Specular Saturation <output data-out="specularSat">1.0</output></span>
+          <input type="range" min="0" max="10" step="0.1" value="1.0" data-tune="specularSat" />
+          <small class="nav-tuner__hint">How vivid the highlight's tint is. 0 = pure grayscale; 1 = neutral; higher = picks up subtle warm/cool color in the glint.</small>
+        </label>
+        <label data-mode="both">
+          <span>Blur Level <output data-out="backdropBlur">1</output>px</span>
+          <input type="range" min="0" max="10" step="0.25" value="1" data-tune="backdropBlur" />
+          <small class="nav-tuner__hint">Frosts the background behind the pill. 0 = sharp; higher = misty. Heavy blur smears the rainbow halo.</small>
+        </label>
+        <label data-mode="both">
+          <span>Progressive Blur <output data-out="progBlur">0</output>px</span>
+          <input type="range" min="0" max="15" step="0.5" value="0" data-tune="progBlur" />
+          <small class="nav-tuner__hint">Gradient blur across the top of the page that fades to clear lower down. Softens the area where content scrolls under the nav.</small>
+        </label>
+        <label data-mode="both">
+          <span>Glass BG Opacity <output data-out="glassBg">0.28</output></span>
+          <input type="range" min="0" max="0.9" step="0.02" value="0.28" data-tune="glassBg" />
+          <small class="nav-tuner__hint">Tint of the panel itself (sits between the lens and what's behind). Higher = more opaque pill.</small>
+        </label>
+
+        <label data-mode="advanced">
+          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.99</output></span>
+          <input type="range" min="0.85" max="0.995" step="0.005" value="0.99" data-tune="clamp" />
           <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
-        <label>
-          <span>Chromatic R scale <output data-out="scaleR">9</output></span>
-          <input type="range" min="0" max="30" step="1" value="9" data-tune="scaleR" />
+        <label data-mode="advanced">
+          <span>Chromatic R scale <output data-out="scaleR">5</output></span>
+          <input type="range" min="0" max="60" step="1" value="5" data-tune="scaleR" />
           <small class="nav-tuner__hint">How far red light is pulled at the rim.</small>
         </label>
-        <label>
-          <span>Chromatic G scale <output data-out="scaleG">11</output></span>
-          <input type="range" min="0" max="30" step="1" value="11" data-tune="scaleG" />
+        <label data-mode="advanced">
+          <span>Chromatic G scale <output data-out="scaleG">6</output></span>
+          <input type="range" min="0" max="60" step="1" value="6" data-tune="scaleG" />
           <small class="nav-tuner__hint">How far green light is pulled at the rim.</small>
         </label>
-        <label>
-          <span>Chromatic B scale <output data-out="scaleB">13</output></span>
-          <input type="range" min="0" max="30" step="1" value="13" data-tune="scaleB" />
-          <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens. Bigger numbers = stronger lens overall.</small>
+        <label data-mode="advanced">
+          <span>Chromatic B scale <output data-out="scaleB">7</output></span>
+          <input type="range" min="0" max="60" step="1" value="7" data-tune="scaleB" />
+          <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens.</small>
         </label>
-        <label>
+        <label data-mode="advanced">
           <span>Map blur (stdDeviation) <output data-out="mapBlur">0.6</output></span>
           <input type="range" min="0" max="2" step="0.05" value="0.6" data-tune="mapBlur" />
           <small class="nav-tuner__hint">Smooths the lens curve so the rim doesn't show stair-steps. A little goes a long way.</small>
         </label>
-        <label>
-          <span>Backdrop blur <output data-out="backdropBlur">1</output>px</span>
-          <input type="range" min="0" max="10" step="0.25" value="1" data-tune="backdropBlur" />
-          <small class="nav-tuner__hint">Frosts the background behind the pill. 0 = sharp; higher = misty. Heavy blur smears the rainbow halo.</small>
-        </label>
-        <label>
+        <label data-mode="advanced">
           <span>Backdrop saturate <output data-out="saturate">180</output>%</span>
           <input type="range" min="50" max="300" step="5" value="180" data-tune="saturate" />
           <small class="nav-tuner__hint">Color punch on whatever's behind the pill. 100% = unchanged; higher = punchier.</small>
         </label>
-        <label>
-          <span>Sheen top alpha <output data-out="sheen">0.30</output></span>
-          <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
-          <small class="nav-tuner__hint">Brightness of the white glint along the top edge — the "light hitting glass" highlight.</small>
-        </label>
 
-        <textarea id="nav-tuner-output" readonly rows="7"></textarea>
+        <textarea id="nav-tuner-output" readonly rows="10"></textarea>
         <div class="nav-tuner__actions">
           <button type="button" id="nav-tuner-copy">Copy values</button>
           <button type="button" id="nav-tuner-reset">Reset</button>
@@ -307,10 +345,66 @@ const isDev = import.meta.env.DEV;
         cursor: pointer;
       }
       .nav-tuner__actions button:hover { background: #44444c; }
+
+      /* Mode toggle pills */
+      .nav-tuner__mode-toggle {
+        display: flex;
+        gap: 4px;
+        padding: 3px;
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 6px;
+      }
+      .nav-tuner__mode-toggle button {
+        flex: 1;
+        background: transparent;
+        color: #e8e8ea;
+        border: none;
+        padding: 5px 8px;
+        font: inherit;
+        font-size: 11px;
+        cursor: pointer;
+        border-radius: 4px;
+        opacity: 0.6;
+        transition: background-color 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-tuner__mode-toggle button.active {
+        background: #34343a;
+        opacity: 1;
+        font-weight: 600;
+      }
+      /* Mode-based visibility — qualified to labels so the mode-toggle buttons
+         (which also carry data-mode) stay visible. */
+      .nav-tuner.mode-simple label[data-mode="advanced"],
+      .nav-tuner.mode-advanced label[data-mode="simple"] {
+        display: none;
+      }
+
+      /* Progressive blur layer — fixed strip at the top of the viewport behind
+         the nav, with a gradient mask so the blur fades from full at the top
+         to clear at the bottom. Default 0px backdrop-filter blur is invisible;
+         the tuner sets it via inline style. */
+      .nav-progressive-blur {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 140px;
+        pointer-events: none;
+        z-index: 39; /* below #site-nav (40) */
+        -webkit-backdrop-filter: blur(0px);
+        backdrop-filter: blur(0px);
+        -webkit-mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 100%);
+        mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 100%);
+      }
     </style>
 
     <script is:inline>
       (function () {
+        // Base chromatic model — Refraction Level (simplified) scales BASE_CENTER,
+        // Chromatic Spread (simplified) is the ±offset of R and B from the center.
+        // Defaults: center=6, spread=1 → 5/6/7 (Apple-style thin-rim refraction).
+        const BASE_CENTER = 6;
+
         function setup() {
           const panel = document.getElementById('nav-tuner-panel');
           if (!panel) return;
@@ -318,71 +412,124 @@ const isDev = import.meta.env.DEV;
           const dispR = document.querySelector('feDisplacementMap[result="dispR"]');
           const dispG = document.querySelector('feDisplacementMap[result="dispG"]');
           const dispB = document.querySelector('feDisplacementMap[result="dispB"]');
-          const mapBlur = document.querySelector('#liquid-glass-distort feGaussianBlur');
+          const mapBlurEl = document.querySelector('#liquid-glass-distort feGaussianBlur');
+          const progLayer = document.querySelector('.nav-progressive-blur');
 
           // Inline override <style> for things JS can't hit directly
-          // (::before pseudo + the !important needed to beat the stylesheet rule).
+          // (::before pseudo + !important needed to beat the stylesheet rule).
           const overrideStyle = document.createElement('style');
           overrideStyle.id = 'nav-tuner-overrides';
           document.head.appendChild(overrideStyle);
 
           const defaults = {
-            clamp: 0.97,
-            scaleR: 9,
-            scaleG: 11,
-            scaleB: 13,
+            // Advanced underlying state
+            clamp: 0.99,
+            scaleR: 5,
+            scaleG: 6,
+            scaleB: 7,
             mapBlur: 0.6,
-            backdropBlur: 1,
             saturate: 180,
+            // Both-mode state
             sheen: 0.30,
+            specularSat: 1.0,
+            backdropBlur: 1,
+            progBlur: 0,
+            glassBg: 0.28,
+            // Simplified-mode derived view: center = BASE_CENTER * refractionLevel,
+            // R/B = center ∓ chromaticSpread.
+            refractionLevel: 1.00,
+            chromaticSpread: 1,
           };
           const state = { ...defaults };
 
+          // Per-key display formatter — keeps the value chip compact and readable.
+          function fmtDisplay(key, v) {
+            if (key === 'clamp') {
+              return v.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
+            }
+            if (
+              key === 'mapBlur' || key === 'sheen' || key === 'glassBg' ||
+              key === 'refractionLevel' || key === 'specularSat'
+            ) {
+              return v.toFixed(2);
+            }
+            return String(v);
+          }
+
+          function applySimpleToScales() {
+            const center = Math.round(BASE_CENTER * state.refractionLevel);
+            state.scaleG = center;
+            state.scaleR = Math.max(0, center - state.chromaticSpread);
+            state.scaleB = center + state.chromaticSpread;
+          }
+
+          function deriveSimpleFromScales() {
+            state.refractionLevel = Math.max(0, Math.min(2, state.scaleG / BASE_CENTER));
+            state.chromaticSpread = Math.max(0, Math.min(10, Math.round((state.scaleB - state.scaleR) / 2)));
+          }
+
           function apply() {
-            // chromatic scales — direct attribute set
+            // SVG primitives: chromatic scales + map blur
             dispR.setAttribute('scale', state.scaleR);
             dispG.setAttribute('scale', state.scaleG);
             dispB.setAttribute('scale', state.scaleB);
-            mapBlur.setAttribute('stdDeviation', state.mapBlur);
+            mapBlurEl.setAttribute('stdDeviation', state.mapBlur);
 
-            // backdrop-filter overrides + sheen pseudo-element via inline style
+            // Progressive-blur strip — inline backdrop-filter
+            if (progLayer) {
+              progLayer.style.webkitBackdropFilter = `blur(${state.progBlur}px)`;
+              progLayer.style.backdropFilter = `blur(${state.progBlur}px)`;
+            }
+
+            // Sheen now uses faint warm-pink top + cool-blue mid stops so
+            // filter: saturate(N) on ::before has actual hue to act on. At
+            // saturate(0) the result reads as pure white; at saturate(>1) the
+            // tints become visible as a subtle iridescence.
             overrideStyle.textContent = `
               @media (min-width: 641px) {
                 #nav-pill {
+                  background: rgba(255, 255, 255, ${state.glassBg}) !important;
                   -webkit-backdrop-filter: blur(${state.backdropBlur}px) saturate(${state.saturate}%) url(#liquid-glass-distort) !important;
                   backdrop-filter: blur(${state.backdropBlur}px) saturate(${state.saturate}%) url(#liquid-glass-distort) !important;
+                }
+                html.dark #nav-pill {
+                  background: rgba(23, 23, 23, ${state.glassBg}) !important;
                 }
                 #nav-pill::before {
                   background: linear-gradient(
                     180deg,
-                    rgba(255, 255, 255, ${state.sheen}) 0%,
-                    rgba(255, 255, 255, ${(state.sheen * 0.2).toFixed(3)}) 40%,
+                    rgba(255, 240, 245, ${state.sheen}) 0%,
+                    rgba(220, 235, 255, ${(state.sheen * 0.2).toFixed(3)}) 40%,
                     transparent 70%
                   ) !important;
+                  filter: saturate(${state.specularSat}) !important;
                 }
                 html.dark #nav-pill::before {
                   background: linear-gradient(
                     180deg,
-                    rgba(255, 255, 255, ${(state.sheen * 0.53).toFixed(3)}) 0%,
-                    rgba(255, 255, 255, ${(state.sheen * 0.1).toFixed(3)}) 40%,
+                    rgba(255, 240, 245, ${(state.sheen * 0.53).toFixed(3)}) 0%,
+                    rgba(220, 235, 255, ${(state.sheen * 0.1).toFixed(3)}) 40%,
                     transparent 70%
                   ) !important;
+                  filter: saturate(${state.specularSat}) !important;
                 }
               }
             `;
 
-            // refresh the values text
             document.getElementById('nav-tuner-output').value = formatValues(state);
           }
 
           function formatValues(s) {
             return [
-              `SQUIRCLE_CLAMP=${s.clamp}`,
+              `SQUIRCLE_CLAMP=${fmtDisplay('clamp', s.clamp)}`,
               `ChromaticScales=${s.scaleR},${s.scaleG},${s.scaleB}`,
               `MapBlur=${s.mapBlur}`,
               `BackdropBlur=${s.backdropBlur}px`,
               `BackdropSaturate=${s.saturate}%`,
               `SheenTop=${s.sheen}`,
+              `SpecularSaturation=${s.specularSat}`,
+              `ProgressiveBlur=${s.progBlur}px`,
+              `GlassBgOpacity=${s.glassBg}`,
             ].join('\n');
           }
 
@@ -398,17 +545,59 @@ const isDev = import.meta.env.DEV;
             });
           }
 
+          // Sync a single slider's input value + output chip to current state.
+          function syncControl(key) {
+            const input = panel.querySelector(`input[data-tune="${key}"]`);
+            const out = panel.querySelector(`output[data-out="${key}"]`);
+            if (input) input.value = state[key];
+            if (out) out.textContent = fmtDisplay(key, state[key]);
+          }
+
           panel.querySelectorAll('input[type="range"]').forEach((input) => {
             const key = input.dataset.tune;
-            const out = panel.querySelector(`output[data-out="${key}"]`);
             input.addEventListener('input', () => {
               const v = parseFloat(input.value);
               state[key] = v;
-              out.textContent = (key === 'clamp' || key === 'mapBlur' || key === 'sheen')
-                ? v.toFixed(2).replace(/\.?0+$/, (m) => m.length === 3 ? m : '')
-                : v;
+              const out = panel.querySelector(`output[data-out="${key}"]`);
+              if (out) out.textContent = fmtDisplay(key, v);
+
               if (key === 'clamp') scheduleRegen();
+
+              // Refraction Level / Chromatic Spread (simplified) → derive R/G/B scales
+              if (key === 'refractionLevel' || key === 'chromaticSpread') {
+                applySimpleToScales();
+                ['scaleR', 'scaleG', 'scaleB'].forEach(syncControl);
+              }
+              // R/G/B (advanced) → derive both simplified controls so toggling
+              // back to Simplified shows values consistent with current state.
+              if (key === 'scaleR' || key === 'scaleG' || key === 'scaleB') {
+                deriveSimpleFromScales();
+                syncControl('refractionLevel');
+                syncControl('chromaticSpread');
+              }
+
               apply();
+            });
+          });
+
+          // Mode toggle
+          panel.querySelectorAll('.nav-tuner__mode-toggle button').forEach((btn) => {
+            btn.addEventListener('click', () => {
+              const mode = btn.dataset.mode;
+              panel.classList.toggle('mode-simple', mode === 'simple');
+              panel.classList.toggle('mode-advanced', mode === 'advanced');
+              panel.querySelectorAll('.nav-tuner__mode-toggle button').forEach((b) => {
+                const active = b.dataset.mode === mode;
+                b.classList.toggle('active', active);
+                b.setAttribute('aria-selected', String(active));
+              });
+              // Re-derive simplified controls when entering simple, in case
+              // advanced edits drifted them from the center+spread model.
+              if (mode === 'simple') {
+                deriveSimpleFromScales();
+                syncControl('refractionLevel');
+                syncControl('chromaticSpread');
+              }
             });
           });
 
@@ -428,10 +617,7 @@ const isDev = import.meta.env.DEV;
           document.getElementById('nav-tuner-reset').addEventListener('click', () => {
             Object.assign(state, defaults);
             panel.querySelectorAll('input[type="range"]').forEach((input) => {
-              const key = input.dataset.tune;
-              input.value = state[key];
-              const out = panel.querySelector(`output[data-out="${key}"]`);
-              out.textContent = state[key];
+              syncControl(input.dataset.tune);
             });
             scheduleRegen();
             apply();

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,13 +26,13 @@ const isDev = import.meta.env.DEV;
     <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
 
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="5"
+                       in="SourceGraphic" in2="map" scale="20"
                        xChannelSelector="R" yChannelSelector="G" result="dispR" />
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="6"
+                       in="SourceGraphic" in2="map" scale="22"
                        xChannelSelector="R" yChannelSelector="G" result="dispG" />
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="7"
+                       in="SourceGraphic" in2="map" scale="24"
                        xChannelSelector="R" yChannelSelector="G" result="dispB" />
 
     <feColorMatrix in="dispR" type="matrix" result="rOnly" values="
@@ -67,7 +67,7 @@ const isDev = import.meta.env.DEV;
     // distance-from-center: |dy/dx| = t³ / (1 − t⁴)^¾. Slope diverges at the
     // rim, so clamp t before the singularity and normalize so the clamped
     // peak maps to 1.
-    let SQUIRCLE_CLAMP = 0.99;
+    let SQUIRCLE_CLAMP = 0.89;
 
     function generateLensMap() {
       const W = 512;
@@ -181,68 +181,68 @@ const isDev = import.meta.env.DEV;
         <label data-mode="simple">
           <span>Refraction Level <output data-out="refractionLevel">1.00</output></span>
           <input type="range" min="0" max="2" step="0.05" value="1.00" data-tune="refractionLevel" />
-          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock; 0 = no bend; 2 = exaggerated. Above 2 the lens enters the inversion regime and projects flipped ghost text — capped here. Use Advanced for full control.</small>
+          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock; 0 = no bend; values above ~1.5 may enter the inversion regime (flipped ghost text inside the pill). Use Advanced for full control.</small>
         </label>
         <label data-mode="simple">
-          <span>Chromatic Spread <output data-out="chromaticSpread">1</output></span>
-          <input type="range" min="0" max="10" step="1" value="1" data-tune="chromaticSpread" />
+          <span>Chromatic Spread <output data-out="chromaticSpread">2</output></span>
+          <input type="range" min="0" max="10" step="1" value="2" data-tune="chromaticSpread" />
           <small class="nav-tuner__hint">Width of the rainbow halo at the rim. 0 = clean lens, no fringe. Higher = stronger color fringing. Independent of overall strength.</small>
         </label>
 
         <label data-mode="both">
-          <span>Specular Opacity <output data-out="sheen">0.30</output></span>
-          <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
+          <span>Specular Opacity <output data-out="sheen">0.20</output></span>
+          <input type="range" min="0" max="0.6" step="0.02" value="0.20" data-tune="sheen" />
           <small class="nav-tuner__hint">Brightness of the white glint along the top edge — the "light hitting glass" highlight.</small>
         </label>
         <label data-mode="both">
-          <span>Specular Saturation <output data-out="specularSat">1.0</output></span>
-          <input type="range" min="0" max="10" step="0.1" value="1.0" data-tune="specularSat" />
+          <span>Specular Saturation <output data-out="specularSat">2.5</output></span>
+          <input type="range" min="0" max="10" step="0.1" value="2.5" data-tune="specularSat" />
           <small class="nav-tuner__hint">How vivid the highlight's tint is. 0 = pure grayscale; 1 = neutral; higher = picks up subtle warm/cool color in the glint.</small>
         </label>
         <label data-mode="both">
-          <span>Blur Level <output data-out="backdropBlur">1</output>px</span>
-          <input type="range" min="0" max="10" step="0.25" value="1" data-tune="backdropBlur" />
+          <span>Blur Level <output data-out="backdropBlur">2.25</output>px</span>
+          <input type="range" min="0" max="10" step="0.25" value="2.25" data-tune="backdropBlur" />
           <small class="nav-tuner__hint">Frosts the background behind the pill. 0 = sharp; higher = misty. Heavy blur smears the rainbow halo.</small>
         </label>
         <label data-mode="both">
-          <span>Progressive Blur <output data-out="progBlur">0</output>px</span>
-          <input type="range" min="0" max="15" step="0.5" value="0" data-tune="progBlur" />
+          <span>Progressive Blur <output data-out="progBlur">0.5</output>px</span>
+          <input type="range" min="0" max="15" step="0.5" value="0.5" data-tune="progBlur" />
           <small class="nav-tuner__hint">Gradient blur across the top of the page that fades to clear lower down. Softens the area where content scrolls under the nav.</small>
         </label>
         <label data-mode="both">
-          <span>Glass BG Opacity <output data-out="glassBg">0.28</output></span>
-          <input type="range" min="0" max="0.9" step="0.02" value="0.28" data-tune="glassBg" />
+          <span>Glass BG Opacity <output data-out="glassBg">0.16</output></span>
+          <input type="range" min="0" max="0.9" step="0.02" value="0.16" data-tune="glassBg" />
           <small class="nav-tuner__hint">Tint of the panel itself (sits between the lens and what's behind). Higher = more opaque pill.</small>
         </label>
 
         <label data-mode="advanced">
-          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.99</output></span>
-          <input type="range" min="0.85" max="0.995" step="0.005" value="0.99" data-tune="clamp" />
+          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.89</output></span>
+          <input type="range" min="0.85" max="0.995" step="0.005" value="0.89" data-tune="clamp" />
           <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic R scale <output data-out="scaleR">5</output></span>
-          <input type="range" min="0" max="60" step="1" value="5" data-tune="scaleR" />
+          <span>Chromatic R scale <output data-out="scaleR">20</output></span>
+          <input type="range" min="0" max="60" step="1" value="20" data-tune="scaleR" />
           <small class="nav-tuner__hint">How far red light is pulled at the rim.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic G scale <output data-out="scaleG">6</output></span>
-          <input type="range" min="0" max="60" step="1" value="6" data-tune="scaleG" />
+          <span>Chromatic G scale <output data-out="scaleG">22</output></span>
+          <input type="range" min="0" max="60" step="1" value="22" data-tune="scaleG" />
           <small class="nav-tuner__hint">How far green light is pulled at the rim.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic B scale <output data-out="scaleB">7</output></span>
-          <input type="range" min="0" max="60" step="1" value="7" data-tune="scaleB" />
+          <span>Chromatic B scale <output data-out="scaleB">24</output></span>
+          <input type="range" min="0" max="60" step="1" value="24" data-tune="scaleB" />
           <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens.</small>
         </label>
         <label data-mode="advanced">
-          <span>Map blur (stdDeviation) <output data-out="mapBlur">0.6</output></span>
-          <input type="range" min="0" max="2" step="0.05" value="0.6" data-tune="mapBlur" />
+          <span>Map blur (stdDeviation) <output data-out="mapBlur">1.4</output></span>
+          <input type="range" min="0" max="2" step="0.05" value="1.4" data-tune="mapBlur" />
           <small class="nav-tuner__hint">Smooths the lens curve so the rim doesn't show stair-steps. A little goes a long way.</small>
         </label>
         <label data-mode="advanced">
-          <span>Backdrop saturate <output data-out="saturate">180</output>%</span>
-          <input type="range" min="50" max="300" step="5" value="180" data-tune="saturate" />
+          <span>Backdrop saturate <output data-out="saturate">125</output>%</span>
+          <input type="range" min="50" max="300" step="5" value="125" data-tune="saturate" />
           <small class="nav-tuner__hint">Color punch on whatever's behind the pill. 100% = unchanged; higher = punchier.</small>
         </label>
 
@@ -402,8 +402,8 @@ const isDev = import.meta.env.DEV;
       (function () {
         // Base chromatic model — Refraction Level (simplified) scales BASE_CENTER,
         // Chromatic Spread (simplified) is the ±offset of R and B from the center.
-        // Defaults: center=6, spread=1 → 5/6/7 (Apple-style thin-rim refraction).
-        const BASE_CENTER = 6;
+        // Defaults: center=22, spread=2 → 20/22/24 (user-tuned visual sweet spot).
+        const BASE_CENTER = 22;
 
         function setup() {
           const panel = document.getElementById('nav-tuner-panel');
@@ -423,22 +423,22 @@ const isDev = import.meta.env.DEV;
 
           const defaults = {
             // Advanced underlying state
-            clamp: 0.99,
-            scaleR: 5,
-            scaleG: 6,
-            scaleB: 7,
-            mapBlur: 0.6,
-            saturate: 180,
+            clamp: 0.89,
+            scaleR: 20,
+            scaleG: 22,
+            scaleB: 24,
+            mapBlur: 1.4,
+            saturate: 125,
             // Both-mode state
-            sheen: 0.30,
-            specularSat: 1.0,
-            backdropBlur: 1,
-            progBlur: 0,
-            glassBg: 0.28,
+            sheen: 0.20,
+            specularSat: 2.5,
+            backdropBlur: 2.25,
+            progBlur: 0.5,
+            glassBg: 0.16,
             // Simplified-mode derived view: center = BASE_CENTER * refractionLevel,
             // R/B = center ∓ chromaticSpread.
             refractionLevel: 1.00,
-            chromaticSpread: 1,
+            chromaticSpread: 2,
           };
           const state = { ...defaults };
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -7,52 +7,34 @@ const isDev = import.meta.env.DEV;
 
 <svg class="liquid-glass-defs" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" color-interpolation-filters="sRGB">
   <!--
-    Liquid glass with chromatic aberration. Per Frontend Masters' "Liquid
-    Glass on the Web" pattern (Chromium-only — Safari/Firefox don't chain
-    SVG filters into backdrop-filter and fall back to plain blur+saturate
-    from .glass).
+    Single-pass liquid glass, ported from the Option E mechanism of
+    themagicianscode.dev/prototypes/liquid-glass-pill: one
+    feDisplacementMap (driven by the canvas-generated 2D displacement
+    map) followed by a heavy feColorMatrix saturate to punch any
+    refracted color through the now-transparent glass. No explicit
+    chromatic-aberration chain — the rainbow fringe at the rim is
+    replaced by amplified color saturation across the displaced
+    backdrop. Chromium-only (Safari/Firefox don't chain SVG filters
+    into backdrop-filter; they fall back to plain blur+saturate).
 
     Pipeline:
-      1. feImage loads the runtime-generated lens displacement map.
-      2. feGaussianBlur smooths the map further to kill stepping artifacts.
-      3. Three feDisplacementMap passes shift R, G, B at slightly different
-         scales — gives chromatic aberration at the rim (rainbow fringe).
-      4. feColorMatrix isolates each channel so we don't double-count.
-      5. feBlend mode="lighten" recombines (per-channel max).
+      1. feImage loads the runtime-generated 2D lens displacement map.
+      2. feGaussianBlur smooths the map to kill stepping artifacts.
+      3. feDisplacementMap warps the backdrop in 2D (R = dx, G = dy).
+      4. feColorMatrix type=saturate punches the color of the result.
   -->
   <filter id="liquid-glass-distort" color-interpolation-filters="sRGB"
           x="0" y="0" width="100%" height="100%">
     <feImage id="liquid-glass-map" href="" preserveAspectRatio="none" result="rawMap" />
     <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
 
-    <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="9"
-                       xChannelSelector="R" yChannelSelector="G" result="dispR" />
-    <feDisplacementMap color-interpolation-filters="sRGB"
+    <feDisplacementMap id="liquid-glass-disp"
+                       color-interpolation-filters="sRGB"
                        in="SourceGraphic" in2="map" scale="12"
-                       xChannelSelector="R" yChannelSelector="G" result="dispG" />
-    <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="15"
-                       xChannelSelector="R" yChannelSelector="G" result="dispB" />
+                       xChannelSelector="R" yChannelSelector="G" result="displaced" />
 
-    <feColorMatrix in="dispR" type="matrix" result="rOnly" values="
-      1 0 0 0 0
-      0 0 0 0 0
-      0 0 0 0 0
-      0 0 0 1 0" />
-    <feColorMatrix in="dispG" type="matrix" result="gOnly" values="
-      0 0 0 0 0
-      0 1 0 0 0
-      0 0 0 0 0
-      0 0 0 1 0" />
-    <feColorMatrix in="dispB" type="matrix" result="bOnly" values="
-      0 0 0 0 0
-      0 0 0 0 0
-      0 0 1 0 0
-      0 0 0 1 0" />
-
-    <feBlend in="rOnly" in2="gOnly" mode="lighten" result="rg" />
-    <feBlend in="rg" in2="bOnly" mode="lighten" />
+    <feColorMatrix id="liquid-glass-saturate"
+                   in="displaced" type="saturate" values="4" />
   </filter>
 </svg>
 
@@ -249,12 +231,12 @@ const isDev = import.meta.env.DEV;
         <label data-mode="simple">
           <span>Refraction Level <output data-out="refractionLevel">1.00</output></span>
           <input type="range" min="0" max="2" step="0.05" value="1.00" data-tune="refractionLevel" />
-          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock (Apple-subtle); 0 = no bend; 2 = exaggerated. Inversion-safe across the whole slider range at the current scales — push individual chromatic scales high in Advanced to trigger inversion intentionally.</small>
+          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock (Apple-subtle); 0 = no bend; 2 = exaggerated. Inversion-safe across the whole slider range at the current scale.</small>
         </label>
-        <label data-mode="simple">
-          <span>Chromatic Spread <output data-out="chromaticSpread">3</output></span>
-          <input type="range" min="0" max="10" step="1" value="3" data-tune="chromaticSpread" />
-          <small class="nav-tuner__hint">Width of the rainbow halo at the rim. 0 = clean lens, no fringe. Higher = stronger color fringing. Independent of overall strength.</small>
+        <label data-mode="both">
+          <span>Color Punch <output data-out="internalSat">4</output></span>
+          <input type="range" min="0" max="10" step="0.25" value="4" data-tune="internalSat" />
+          <small class="nav-tuner__hint">How vivid the refracted backdrop reads through the glass. 0 = grayscale (no color); 1 = unchanged; 4 = strong (Apple-style); higher = oversaturated. Applied as feColorMatrix saturate inside the filter, the prototype's actual mechanism.</small>
         </label>
 
         <label data-mode="both">
@@ -289,19 +271,9 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic R scale <output data-out="scaleR">9</output></span>
-          <input type="range" min="0" max="60" step="1" value="9" data-tune="scaleR" />
-          <small class="nav-tuner__hint">How far red light is pulled at the rim.</small>
-        </label>
-        <label data-mode="advanced">
-          <span>Chromatic G scale <output data-out="scaleG">12</output></span>
-          <input type="range" min="0" max="60" step="1" value="12" data-tune="scaleG" />
-          <small class="nav-tuner__hint">How far green light is pulled at the rim.</small>
-        </label>
-        <label data-mode="advanced">
-          <span>Chromatic B scale <output data-out="scaleB">15</output></span>
-          <input type="range" min="0" max="60" step="1" value="15" data-tune="scaleB" />
-          <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens.</small>
+          <span>Refraction Scale <output data-out="scale">12</output></span>
+          <input type="range" min="0" max="60" step="1" value="12" data-tune="scale" />
+          <small class="nav-tuner__hint">Pixel displacement at the rim — the absolute scale on feDisplacementMap. Refraction Level multiplies BASE_CENTER (=12) to derive this; tweak directly to override.</small>
         </label>
         <label data-mode="advanced">
           <span>Map blur (stdDeviation) <output data-out="mapBlur">1.4</output></span>
@@ -309,9 +281,9 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Smooths the lens curve so the rim doesn't show stair-steps. A little goes a long way.</small>
         </label>
         <label data-mode="advanced">
-          <span>Backdrop saturate <output data-out="saturate">300</output>%</span>
-          <input type="range" min="50" max="500" step="5" value="300" data-tune="saturate" />
-          <small class="nav-tuner__hint">Color punch on whatever's behind the pill. 100% = unchanged; higher = punchier.</small>
+          <span>Backdrop saturate (pre-filter) <output data-out="saturate">100</output>%</span>
+          <input type="range" min="50" max="500" step="5" value="100" data-tune="saturate" />
+          <small class="nav-tuner__hint">Saturation applied by CSS backdrop-filter <em>before</em> the SVG sees the backdrop. Stacks multiplicatively with Color Punch. 100% = no extra punch.</small>
         </label>
 
         <textarea id="nav-tuner-output" readonly rows="10"></textarea>
@@ -479,9 +451,8 @@ const isDev = import.meta.env.DEV;
           const panel = document.getElementById('nav-tuner-panel');
           if (!panel) return;
 
-          const dispR = document.querySelector('feDisplacementMap[result="dispR"]');
-          const dispG = document.querySelector('feDisplacementMap[result="dispG"]');
-          const dispB = document.querySelector('feDisplacementMap[result="dispB"]');
+          const disp = document.getElementById('liquid-glass-disp');
+          const satMatrix = document.getElementById('liquid-glass-saturate');
           const mapBlurEl = document.querySelector('#liquid-glass-distort feGaussianBlur');
           const progLayer = document.querySelector('.nav-progressive-blur');
 
@@ -494,21 +465,18 @@ const isDev = import.meta.env.DEV;
           const defaults = {
             // Advanced underlying state
             clamp: 0.97,
-            scaleR: 9,
-            scaleG: 12,
-            scaleB: 15,
+            scale: 12,
             mapBlur: 1.4,
-            saturate: 300,
+            saturate: 100,            // CSS backdrop-filter saturate (pre-SVG)
             // Both-mode state
             sheen: 0.30,
             specularSat: 2.5,
             backdropBlur: 7,
             progBlur: 0.5,
             glassBg: 0.06,
-            // Simplified-mode derived view: center = BASE_CENTER * refractionLevel,
-            // R/B = center ∓ chromaticSpread.
+            internalSat: 4,           // feColorMatrix saturate (post-displacement)
+            // Simplified-mode derived view: scale = BASE_CENTER * refractionLevel
             refractionLevel: 1.00,
-            chromaticSpread: 3,
           };
           const state = { ...defaults };
 
@@ -519,31 +487,27 @@ const isDev = import.meta.env.DEV;
             }
             if (
               key === 'mapBlur' || key === 'sheen' || key === 'glassBg' ||
-              key === 'refractionLevel' || key === 'specularSat'
+              key === 'refractionLevel' || key === 'specularSat' ||
+              key === 'internalSat'
             ) {
               return v.toFixed(2);
             }
             return String(v);
           }
 
-          function applySimpleToScales() {
-            const center = Math.round(BASE_CENTER * state.refractionLevel);
-            state.scaleG = center;
-            state.scaleR = Math.max(0, center - state.chromaticSpread);
-            state.scaleB = center + state.chromaticSpread;
+          function applySimpleToScale() {
+            state.scale = Math.round(BASE_CENTER * state.refractionLevel);
           }
 
-          function deriveSimpleFromScales() {
-            state.refractionLevel = Math.max(0, Math.min(2, state.scaleG / BASE_CENTER));
-            state.chromaticSpread = Math.max(0, Math.min(10, Math.round((state.scaleB - state.scaleR) / 2)));
+          function deriveSimpleFromScale() {
+            state.refractionLevel = Math.max(0, Math.min(2, state.scale / BASE_CENTER));
           }
 
           function apply() {
-            // SVG primitives: chromatic scales + map blur
-            dispR.setAttribute('scale', state.scaleR);
-            dispG.setAttribute('scale', state.scaleG);
-            dispB.setAttribute('scale', state.scaleB);
+            // SVG primitives: single displacement scale + map blur + internal saturate
+            disp.setAttribute('scale', state.scale);
             mapBlurEl.setAttribute('stdDeviation', state.mapBlur);
+            satMatrix.setAttribute('values', state.internalSat);
 
             // Progressive-blur strip — inline backdrop-filter
             if (progLayer) {
@@ -592,7 +556,8 @@ const isDev = import.meta.env.DEV;
           function formatValues(s) {
             return [
               `SQUIRCLE_CLAMP=${fmtDisplay('clamp', s.clamp)}`,
-              `ChromaticScales=${s.scaleR},${s.scaleG},${s.scaleB}`,
+              `RefractionScale=${s.scale}`,
+              `InternalSaturate=${fmtDisplay('internalSat', s.internalSat)}`,
               `MapBlur=${s.mapBlur}`,
               `BackdropBlur=${s.backdropBlur}px`,
               `BackdropSaturate=${s.saturate}%`,
@@ -633,17 +598,16 @@ const isDev = import.meta.env.DEV;
 
               if (key === 'clamp') scheduleRegen();
 
-              // Refraction Level / Chromatic Spread (simplified) → derive R/G/B scales
-              if (key === 'refractionLevel' || key === 'chromaticSpread') {
-                applySimpleToScales();
-                ['scaleR', 'scaleG', 'scaleB'].forEach(syncControl);
+              // Refraction Level (simplified) → derive single scale
+              if (key === 'refractionLevel') {
+                applySimpleToScale();
+                syncControl('scale');
               }
-              // R/G/B (advanced) → derive both simplified controls so toggling
-              // back to Simplified shows values consistent with current state.
-              if (key === 'scaleR' || key === 'scaleG' || key === 'scaleB') {
-                deriveSimpleFromScales();
+              // Refraction Scale (advanced) → derive Refraction Level so
+              // toggling to Simplified shows a value consistent with state.
+              if (key === 'scale') {
+                deriveSimpleFromScale();
                 syncControl('refractionLevel');
-                syncControl('chromaticSpread');
               }
 
               apply();
@@ -661,12 +625,11 @@ const isDev = import.meta.env.DEV;
                 b.classList.toggle('active', active);
                 b.setAttribute('aria-selected', String(active));
               });
-              // Re-derive simplified controls when entering simple, in case
-              // advanced edits drifted them from the center+spread model.
+              // Re-derive Refraction Level when entering Simplified, in case
+              // advanced edits drifted scale away from BASE_CENTER × level.
               if (mode === 'simple') {
-                deriveSimpleFromScales();
+                deriveSimpleFromScale();
                 syncControl('refractionLevel');
-                syncControl('chromaticSpread');
               }
             });
           });

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,9 +1,11 @@
 ---
 import { Icon } from 'astro-icon/components';
 import ThemeToggle from './ThemeToggle.astro';
+
+const isDev = import.meta.env.DEV;
 ---
 
-<svg class="liquid-glass-defs" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
+<svg class="liquid-glass-defs" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" color-interpolation-filters="sRGB">
   <!--
     Liquid glass with chromatic aberration. Per Frontend Masters' "Liquid
     Glass on the Web" pattern (Chromium-only — Safari/Firefox don't chain
@@ -55,52 +57,65 @@ import ThemeToggle from './ThemeToggle.astro';
   // into the SVG filter. Encodes inward refraction at the rim, no displacement
   // at the center — simulates real glass curvature.
   (function () {
-    const W = 512;
-    const H = 96;
-    const canvas = document.createElement('canvas');
-    canvas.width = W;
-    canvas.height = H;
-    const ctx = canvas.getContext('2d');
-    const img = ctx.createImageData(W, H);
-    const data = img.data;
-
     // Squircle profile (Apple's preferred curve, per kube.io/blog/liquid-glass-css-svg).
     // Surface y = ⁴√(1 − (1 − x)⁴) where x = distance-from-edge. Snell's-law
     // refraction is proportional to the surface slope; in terms of t =
     // distance-from-center: |dy/dx| = t³ / (1 − t⁴)^¾. Slope diverges at the
     // rim, so clamp t before the singularity and normalize so the clamped
     // peak maps to 1.
-    const SQUIRCLE_CLAMP = 0.97;
-    const squircleSlope = (t) => {
-      const tc = Math.min(t, SQUIRCLE_CLAMP);
-      return Math.pow(tc, 3) / Math.pow(1 - Math.pow(tc, 4), 0.75);
-    };
-    const maxSlope = squircleSlope(SQUIRCLE_CLAMP);
+    let SQUIRCLE_CLAMP = 0.97;
 
-    // Vertical-only lens — a wide horizontal pill is best modelled as a
-    // cylindrical lens. R channel stays at 128 (no horizontal shift) so text
-    // passing under the pill doesn't compress horizontally. Only Y refracts.
-    for (let y = 0; y < H; y++) {
-      for (let x = 0; x < W; x++) {
-        const fy = (y / (H - 1)) * 2 - 1;
-        const shiftY = -Math.sign(fy) * (squircleSlope(Math.abs(fy)) / maxSlope);
+    function generateLensMap() {
+      const W = 512;
+      const H = 96;
+      const canvas = document.createElement('canvas');
+      canvas.width = W;
+      canvas.height = H;
+      const ctx = canvas.getContext('2d');
+      const img = ctx.createImageData(W, H);
+      const data = img.data;
 
-        const i = (y * W + x) * 4;
-        data[i] = 128;                                // R = 128 (no X shift)
-        data[i + 1] = Math.round(128 + shiftY * 127); // G = Y displacement
-        data[i + 2] = 0;
-        data[i + 3] = 255;
+      const squircleSlope = (t) => {
+        const tc = Math.min(t, SQUIRCLE_CLAMP);
+        return Math.pow(tc, 3) / Math.pow(1 - Math.pow(tc, 4), 0.75);
+      };
+      const maxSlope = squircleSlope(SQUIRCLE_CLAMP);
+
+      // Vertical-only lens — a wide horizontal pill is best modelled as a
+      // cylindrical lens. R channel stays at 128 (no horizontal shift) so text
+      // passing under the pill doesn't compress horizontally. Only Y refracts.
+      for (let y = 0; y < H; y++) {
+        for (let x = 0; x < W; x++) {
+          const fy = (y / (H - 1)) * 2 - 1;
+          const shiftY = -Math.sign(fy) * (squircleSlope(Math.abs(fy)) / maxSlope);
+
+          const i = (y * W + x) * 4;
+          data[i] = 128;                                // R = 128 (no X shift)
+          data[i + 1] = Math.round(128 + shiftY * 127); // G = Y displacement
+          data[i + 2] = 0;
+          data[i + 3] = 255;
+        }
+      }
+
+      ctx.putImageData(img, 0, 0);
+      const url = canvas.toDataURL('image/png');
+
+      const feImg = document.getElementById('liquid-glass-map');
+      if (feImg) {
+        feImg.setAttribute('href', url);
+        feImg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', url);
       }
     }
 
-    ctx.putImageData(img, 0, 0);
-    const url = canvas.toDataURL('image/png');
+    generateLensMap();
 
-    const feImg = document.getElementById('liquid-glass-map');
-    if (feImg) {
-      feImg.setAttribute('href', url);
-      feImg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', url);
-    }
+    // Dev tuner hook — listens for clamp updates from NavTuner and regenerates.
+    window.addEventListener('navlens:setClamp', (e) => {
+      if (e.detail && typeof e.detail.value === 'number') {
+        SQUIRCLE_CLAMP = e.detail.value;
+        generateLensMap();
+      }
+    });
   })();
 </script>
 
@@ -143,3 +158,284 @@ import ThemeToggle from './ThemeToggle.astro';
     </div>
   </div>
 </nav>
+
+{isDev && (
+  <Fragment>
+    <aside id="nav-tuner-panel" class="nav-tuner" aria-label="Liquid glass tuner">
+      <header class="nav-tuner__head">
+        <span>Nav glass tuner</span>
+        <button type="button" id="nav-tuner-toggle" aria-label="Collapse tuner">−</button>
+      </header>
+      <div class="nav-tuner__body">
+        <label>
+          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.97</output></span>
+          <input type="range" min="0.85" max="0.995" step="0.005" value="0.97" data-tune="clamp" />
+        </label>
+        <label>
+          <span>Chromatic R scale <output data-out="scaleR">9</output></span>
+          <input type="range" min="0" max="30" step="1" value="9" data-tune="scaleR" />
+        </label>
+        <label>
+          <span>Chromatic G scale <output data-out="scaleG">11</output></span>
+          <input type="range" min="0" max="30" step="1" value="11" data-tune="scaleG" />
+        </label>
+        <label>
+          <span>Chromatic B scale <output data-out="scaleB">13</output></span>
+          <input type="range" min="0" max="30" step="1" value="13" data-tune="scaleB" />
+        </label>
+        <label>
+          <span>Map blur (stdDeviation) <output data-out="mapBlur">0.6</output></span>
+          <input type="range" min="0" max="2" step="0.05" value="0.6" data-tune="mapBlur" />
+        </label>
+        <label>
+          <span>Backdrop blur <output data-out="backdropBlur">1</output>px</span>
+          <input type="range" min="0" max="10" step="0.25" value="1" data-tune="backdropBlur" />
+        </label>
+        <label>
+          <span>Backdrop saturate <output data-out="saturate">180</output>%</span>
+          <input type="range" min="50" max="300" step="5" value="180" data-tune="saturate" />
+        </label>
+        <label>
+          <span>Sheen top alpha <output data-out="sheen">0.30</output></span>
+          <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
+        </label>
+
+        <textarea id="nav-tuner-output" readonly rows="7"></textarea>
+        <div class="nav-tuner__actions">
+          <button type="button" id="nav-tuner-copy">Copy values</button>
+          <button type="button" id="nav-tuner-reset">Reset</button>
+        </div>
+      </div>
+    </aside>
+
+    <style is:global>
+      .nav-tuner {
+        position: fixed;
+        bottom: 12px;
+        right: 12px;
+        width: 280px;
+        max-height: calc(100vh - 24px);
+        overflow: auto;
+        background: rgba(20, 20, 24, 0.94);
+        color: #e8e8ea;
+        font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 255, 255, 0.10);
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+        z-index: 9999;
+      }
+      .nav-tuner__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 12px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.10);
+        font-weight: 600;
+      }
+      .nav-tuner__head button {
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 16px;
+        line-height: 1;
+        cursor: pointer;
+        padding: 2px 6px;
+      }
+      .nav-tuner__body {
+        padding: 10px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .nav-tuner.collapsed .nav-tuner__body { display: none; }
+      .nav-tuner label {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+      }
+      .nav-tuner label > span {
+        display: flex;
+        justify-content: space-between;
+        opacity: 0.85;
+      }
+      .nav-tuner output {
+        color: #9be8a3;
+        font-weight: 600;
+      }
+      .nav-tuner input[type="range"] {
+        width: 100%;
+        accent-color: #9be8a3;
+      }
+      .nav-tuner textarea {
+        width: 100%;
+        background: rgba(0, 0, 0, 0.45);
+        color: #e8e8ea;
+        border: 1px solid rgba(255, 255, 255, 0.10);
+        border-radius: 5px;
+        padding: 8px;
+        font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        resize: vertical;
+        margin-top: 4px;
+      }
+      .nav-tuner__actions {
+        display: flex;
+        gap: 8px;
+      }
+      .nav-tuner__actions button {
+        flex: 1;
+        background: #34343a;
+        color: #e8e8ea;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 5px;
+        padding: 6px 10px;
+        font: inherit;
+        cursor: pointer;
+      }
+      .nav-tuner__actions button:hover { background: #44444c; }
+    </style>
+
+    <script is:inline>
+      (function () {
+        function setup() {
+          const panel = document.getElementById('nav-tuner-panel');
+          if (!panel) return;
+
+          const dispR = document.querySelector('feDisplacementMap[result="dispR"]');
+          const dispG = document.querySelector('feDisplacementMap[result="dispG"]');
+          const dispB = document.querySelector('feDisplacementMap[result="dispB"]');
+          const mapBlur = document.querySelector('#liquid-glass-distort feGaussianBlur');
+
+          // Inline override <style> for things JS can't hit directly
+          // (::before pseudo + the !important needed to beat the stylesheet rule).
+          const overrideStyle = document.createElement('style');
+          overrideStyle.id = 'nav-tuner-overrides';
+          document.head.appendChild(overrideStyle);
+
+          const defaults = {
+            clamp: 0.97,
+            scaleR: 9,
+            scaleG: 11,
+            scaleB: 13,
+            mapBlur: 0.6,
+            backdropBlur: 1,
+            saturate: 180,
+            sheen: 0.30,
+          };
+          const state = { ...defaults };
+
+          function apply() {
+            // chromatic scales — direct attribute set
+            dispR.setAttribute('scale', state.scaleR);
+            dispG.setAttribute('scale', state.scaleG);
+            dispB.setAttribute('scale', state.scaleB);
+            mapBlur.setAttribute('stdDeviation', state.mapBlur);
+
+            // backdrop-filter overrides + sheen pseudo-element via inline style
+            overrideStyle.textContent = `
+              @media (min-width: 641px) {
+                #nav-pill {
+                  -webkit-backdrop-filter: blur(${state.backdropBlur}px) saturate(${state.saturate}%) url(#liquid-glass-distort) !important;
+                  backdrop-filter: blur(${state.backdropBlur}px) saturate(${state.saturate}%) url(#liquid-glass-distort) !important;
+                }
+                #nav-pill::before {
+                  background: linear-gradient(
+                    180deg,
+                    rgba(255, 255, 255, ${state.sheen}) 0%,
+                    rgba(255, 255, 255, ${(state.sheen * 0.2).toFixed(3)}) 40%,
+                    transparent 70%
+                  ) !important;
+                }
+                html.dark #nav-pill::before {
+                  background: linear-gradient(
+                    180deg,
+                    rgba(255, 255, 255, ${(state.sheen * 0.53).toFixed(3)}) 0%,
+                    rgba(255, 255, 255, ${(state.sheen * 0.1).toFixed(3)}) 40%,
+                    transparent 70%
+                  ) !important;
+                }
+              }
+            `;
+
+            // refresh the values text
+            document.getElementById('nav-tuner-output').value = formatValues(state);
+          }
+
+          function formatValues(s) {
+            return [
+              `SQUIRCLE_CLAMP=${s.clamp}`,
+              `ChromaticScales=${s.scaleR},${s.scaleG},${s.scaleB}`,
+              `MapBlur=${s.mapBlur}`,
+              `BackdropBlur=${s.backdropBlur}px`,
+              `BackdropSaturate=${s.saturate}%`,
+              `SheenTop=${s.sheen}`,
+            ].join('\n');
+          }
+
+          let regenScheduled = false;
+          function scheduleRegen() {
+            if (regenScheduled) return;
+            regenScheduled = true;
+            requestAnimationFrame(() => {
+              regenScheduled = false;
+              window.dispatchEvent(new CustomEvent('navlens:setClamp', {
+                detail: { value: state.clamp }
+              }));
+            });
+          }
+
+          panel.querySelectorAll('input[type="range"]').forEach((input) => {
+            const key = input.dataset.tune;
+            const out = panel.querySelector(`output[data-out="${key}"]`);
+            input.addEventListener('input', () => {
+              const v = parseFloat(input.value);
+              state[key] = v;
+              out.textContent = (key === 'clamp' || key === 'mapBlur' || key === 'sheen')
+                ? v.toFixed(2).replace(/\.?0+$/, (m) => m.length === 3 ? m : '')
+                : v;
+              if (key === 'clamp') scheduleRegen();
+              apply();
+            });
+          });
+
+          document.getElementById('nav-tuner-copy').addEventListener('click', async (ev) => {
+            const text = formatValues(state);
+            try {
+              await navigator.clipboard.writeText(text);
+              ev.target.textContent = 'Copied ✓';
+              setTimeout(() => { ev.target.textContent = 'Copy values'; }, 1200);
+            } catch {
+              const ta = document.getElementById('nav-tuner-output');
+              ta.select();
+              document.execCommand('copy');
+            }
+          });
+
+          document.getElementById('nav-tuner-reset').addEventListener('click', () => {
+            Object.assign(state, defaults);
+            panel.querySelectorAll('input[type="range"]').forEach((input) => {
+              const key = input.dataset.tune;
+              input.value = state[key];
+              const out = panel.querySelector(`output[data-out="${key}"]`);
+              out.textContent = state[key];
+            });
+            scheduleRegen();
+            apply();
+          });
+
+          document.getElementById('nav-tuner-toggle').addEventListener('click', (ev) => {
+            panel.classList.toggle('collapsed');
+            ev.target.textContent = panel.classList.contains('collapsed') ? '+' : '−';
+          });
+
+          apply();
+        }
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', setup);
+        } else {
+          setup();
+        }
+      })();
+    </script>
+  </Fragment>
+)}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -278,8 +278,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Gradient blur across the top of the page that fades to clear lower down. Softens the area where content scrolls under the nav.</small>
         </label>
         <label data-mode="both">
-          <span>Glass BG Opacity <output data-out="glassBg">0.16</output></span>
-          <input type="range" min="0" max="0.9" step="0.02" value="0.16" data-tune="glassBg" />
+          <span>Glass BG Opacity <output data-out="glassBg">0.06</output></span>
+          <input type="range" min="0" max="0.9" step="0.02" value="0.06" data-tune="glassBg" />
           <small class="nav-tuner__hint">Tint of the panel itself (sits between the lens and what's behind). Higher = more opaque pill.</small>
         </label>
 
@@ -309,8 +309,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Smooths the lens curve so the rim doesn't show stair-steps. A little goes a long way.</small>
         </label>
         <label data-mode="advanced">
-          <span>Backdrop saturate <output data-out="saturate">125</output>%</span>
-          <input type="range" min="50" max="300" step="5" value="125" data-tune="saturate" />
+          <span>Backdrop saturate <output data-out="saturate">300</output>%</span>
+          <input type="range" min="50" max="500" step="5" value="300" data-tune="saturate" />
           <small class="nav-tuner__hint">Color punch on whatever's behind the pill. 100% = unchanged; higher = punchier.</small>
         </label>
 
@@ -498,13 +498,13 @@ const isDev = import.meta.env.DEV;
             scaleG: 12,
             scaleB: 15,
             mapBlur: 1.4,
-            saturate: 125,
+            saturate: 300,
             // Both-mode state
             sheen: 0.30,
             specularSat: 2.5,
             backdropBlur: 7,
             progBlur: 0.5,
-            glassBg: 0.16,
+            glassBg: 0.06,
             // Simplified-mode derived view: center = BASE_CENTER * refractionLevel,
             // R/B = center ∓ chromaticSpread.
             refractionLevel: 1.00,

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -57,21 +57,31 @@ const isDev = import.meta.env.DEV;
 </svg>
 
 <script is:inline>
-  // Generate a pill-shaped lens displacement map at page load and inject it
-  // into the SVG filter. Encodes inward refraction at the rim, no displacement
-  // at the center — simulates real glass curvature.
+  // 2D pill-shape displacement map, generated at the actual pill dimensions
+  // and re-generated when the pill resizes. Encodes both X (R channel) and
+  // Y (G channel) displacement so the rounded corners wrap content from
+  // the opposite side of the pill — the corner-wrap effect Apple's pills
+  // exhibit, that pure cylindrical (Y-only) refraction cannot reproduce.
+  //
+  // Per pixel, the shape is decomposed into:
+  //   - Central flat section: pure vertical refraction (cylindrical lens)
+  //   - Two rounded ends:     radial refraction toward the corner center
+  // Pixels outside the pill rim (corners of the rectangular canvas not
+  // covered by the rounded shape) encode no displacement (R=G=128).
+  //
+  // Squircle profile from kube.io/blog/liquid-glass-css-svg: refraction
+  // magnitude follows |dy/dx| = t³ / (1 − t⁴)^¾ where t is normalized
+  // distance from center toward the nearest rim point. Clamped before
+  // the singularity at t=1, normalized so the clamp value maps to 1.0.
   (function () {
-    // Squircle profile (Apple's preferred curve, per kube.io/blog/liquid-glass-css-svg).
-    // Surface y = ⁴√(1 − (1 − x)⁴) where x = distance-from-edge. Snell's-law
-    // refraction is proportional to the surface slope; in terms of t =
-    // distance-from-center: |dy/dx| = t³ / (1 − t⁴)^¾. Slope diverges at the
-    // rim, so clamp t before the singularity and normalize so the clamped
-    // peak maps to 1.
     let SQUIRCLE_CLAMP = 0.97;
 
-    function generateLensMap() {
-      const W = 512;
-      const H = 96;
+    function squircleSlope(t) {
+      const tc = Math.min(t, SQUIRCLE_CLAMP);
+      return Math.pow(tc, 3) / Math.pow(1 - Math.pow(tc, 4), 0.75);
+    }
+
+    function generateLensMap(W, H) {
       const canvas = document.createElement('canvas');
       canvas.width = W;
       canvas.height = H;
@@ -79,45 +89,103 @@ const isDev = import.meta.env.DEV;
       const img = ctx.createImageData(W, H);
       const data = img.data;
 
-      const squircleSlope = (t) => {
-        const tc = Math.min(t, SQUIRCLE_CLAMP);
-        return Math.pow(tc, 3) / Math.pow(1 - Math.pow(tc, 4), 0.75);
-      };
+      const Wh = W / 2;
+      const Hh = H / 2;
+      const radius = Hh; // full-radius pill (border-radius: 999px)
+      const flatHalfW = Math.max(0, Wh - Hh); // length of central flat half
       const maxSlope = squircleSlope(SQUIRCLE_CLAMP);
 
-      // Vertical-only lens — a wide horizontal pill is best modelled as a
-      // cylindrical lens. R channel stays at 128 (no horizontal shift) so text
-      // passing under the pill doesn't compress horizontally. Only Y refracts.
       for (let y = 0; y < H; y++) {
         for (let x = 0; x < W; x++) {
-          const fy = (y / (H - 1)) * 2 - 1;
-          const shiftY = -Math.sign(fy) * (squircleSlope(Math.abs(fy)) / maxSlope);
+          // Pixel-center coords relative to pill center
+          const px = x + 0.5 - Wh;
+          const py = y + 0.5 - Hh;
+
+          let d, dirX, dirY;
+
+          if (Math.abs(px) <= flatHalfW) {
+            // Central flat section — Y refraction only (cylindrical)
+            d = radius - Math.abs(py);
+            dirX = 0;
+            dirY = py === 0 ? 0 : -Math.sign(py);
+          } else {
+            // Rounded end — radial refraction toward the corner center
+            const cx = Math.sign(px) * flatHalfW;
+            const dxC = px - cx;
+            const dyC = py;
+            const distFromCorner = Math.sqrt(dxC * dxC + dyC * dyC);
+            d = radius - distFromCorner;
+            if (distFromCorner > 0.001) {
+              dirX = -dxC / distFromCorner;
+              dirY = -dyC / distFromCorner;
+            } else {
+              dirX = 0;
+              dirY = 0;
+            }
+          }
 
           const i = (y * W + x) * 4;
-          data[i] = 128;                                // R = 128 (no X shift)
-          data[i + 1] = Math.round(128 + shiftY * 127); // G = Y displacement
+
+          if (d < 0) {
+            // Outside the pill rim — encode neutral (no displacement)
+            data[i] = 128;
+            data[i + 1] = 128;
+          } else {
+            const r = 1 - d / radius; // 0 at center, 1 at rim
+            const magnitude = squircleSlope(r) / maxSlope;
+            data[i] = Math.round(128 + dirX * magnitude * 127);
+            data[i + 1] = Math.round(128 + dirY * magnitude * 127);
+          }
           data[i + 2] = 0;
           data[i + 3] = 255;
         }
       }
 
       ctx.putImageData(img, 0, 0);
-      const url = canvas.toDataURL('image/png');
-
-      const feImg = document.getElementById('liquid-glass-map');
-      if (feImg) {
-        feImg.setAttribute('href', url);
-        feImg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', url);
-      }
+      return canvas.toDataURL('image/png');
     }
 
-    generateLensMap();
+    function regenerate() {
+      const pill = document.getElementById('nav-pill');
+      const feImg = document.getElementById('liquid-glass-map');
+      if (!pill || !feImg) return;
+      const rect = pill.getBoundingClientRect();
+      const W = Math.round(rect.width);
+      const H = Math.round(rect.height);
+      if (W <= 0 || H <= 0) return;
+      const url = generateLensMap(W, H);
+      feImg.setAttribute('href', url);
+      feImg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', url);
+    }
+
+    let resizeTimer;
+    let resizeObserver;
+    function observePill() {
+      const pill = document.getElementById('nav-pill');
+      if (!pill || resizeObserver) return;
+      resizeObserver = new ResizeObserver(() => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(regenerate, 80);
+      });
+      resizeObserver.observe(pill);
+    }
+
+    function init() {
+      regenerate();
+      observePill();
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
 
     // Dev tuner hook — listens for clamp updates from NavTuner and regenerates.
     window.addEventListener('navlens:setClamp', (e) => {
       if (e.detail && typeof e.detail.value === 'number') {
         SQUIRCLE_CLAMP = e.detail.value;
-        generateLensMap();
+        regenerate();
       }
     });
   })();

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -67,7 +67,7 @@ const isDev = import.meta.env.DEV;
     // distance-from-center: |dy/dx| = t³ / (1 − t⁴)^¾. Slope diverges at the
     // rim, so clamp t before the singularity and normalize so the clamped
     // peak maps to 1.
-    let SQUIRCLE_CLAMP = 0.89;
+    let SQUIRCLE_CLAMP = 0.97;
 
     function generateLensMap() {
       const W = 512;
@@ -216,8 +216,8 @@ const isDev = import.meta.env.DEV;
         </label>
 
         <label data-mode="advanced">
-          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.89</output></span>
-          <input type="range" min="0.85" max="0.995" step="0.005" value="0.89" data-tune="clamp" />
+          <span>SQUIRCLE_CLAMP <output data-out="clamp">0.97</output></span>
+          <input type="range" min="0.85" max="0.995" step="0.005" value="0.97" data-tune="clamp" />
           <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
         <label data-mode="advanced">
@@ -423,7 +423,7 @@ const isDev = import.meta.env.DEV;
 
           const defaults = {
             // Advanced underlying state
-            clamp: 0.89,
+            clamp: 0.97,
             scaleR: 20,
             scaleG: 22,
             scaleB: 24,

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,13 +26,13 @@ const isDev = import.meta.env.DEV;
     <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
 
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="10"
+                       in="SourceGraphic" in2="map" scale="9"
                        xChannelSelector="R" yChannelSelector="G" result="dispR" />
     <feDisplacementMap color-interpolation-filters="sRGB"
                        in="SourceGraphic" in2="map" scale="12"
                        xChannelSelector="R" yChannelSelector="G" result="dispG" />
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="14"
+                       in="SourceGraphic" in2="map" scale="15"
                        xChannelSelector="R" yChannelSelector="G" result="dispB" />
 
     <feColorMatrix in="dispR" type="matrix" result="rOnly" values="
@@ -184,14 +184,14 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock (Apple-subtle); 0 = no bend; 2 = exaggerated. Inversion-safe across the whole slider range at the current scales — push individual chromatic scales high in Advanced to trigger inversion intentionally.</small>
         </label>
         <label data-mode="simple">
-          <span>Chromatic Spread <output data-out="chromaticSpread">2</output></span>
-          <input type="range" min="0" max="10" step="1" value="2" data-tune="chromaticSpread" />
+          <span>Chromatic Spread <output data-out="chromaticSpread">3</output></span>
+          <input type="range" min="0" max="10" step="1" value="3" data-tune="chromaticSpread" />
           <small class="nav-tuner__hint">Width of the rainbow halo at the rim. 0 = clean lens, no fringe. Higher = stronger color fringing. Independent of overall strength.</small>
         </label>
 
         <label data-mode="both">
-          <span>Specular Opacity <output data-out="sheen">0.20</output></span>
-          <input type="range" min="0" max="0.6" step="0.02" value="0.20" data-tune="sheen" />
+          <span>Specular Opacity <output data-out="sheen">0.30</output></span>
+          <input type="range" min="0" max="0.6" step="0.02" value="0.30" data-tune="sheen" />
           <small class="nav-tuner__hint">Brightness of the white glint along the top edge — the "light hitting glass" highlight.</small>
         </label>
         <label data-mode="both">
@@ -200,8 +200,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">How vivid the highlight's tint is. 0 = pure grayscale; 1 = neutral; higher = picks up subtle warm/cool color in the glint.</small>
         </label>
         <label data-mode="both">
-          <span>Blur Level <output data-out="backdropBlur">2.25</output>px</span>
-          <input type="range" min="0" max="10" step="0.25" value="2.25" data-tune="backdropBlur" />
+          <span>Blur Level <output data-out="backdropBlur">7</output>px</span>
+          <input type="range" min="0" max="10" step="0.25" value="7" data-tune="backdropBlur" />
           <small class="nav-tuner__hint">Frosts the background behind the pill. 0 = sharp; higher = misty. Heavy blur smears the rainbow halo.</small>
         </label>
         <label data-mode="both">
@@ -221,8 +221,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic R scale <output data-out="scaleR">10</output></span>
-          <input type="range" min="0" max="60" step="1" value="10" data-tune="scaleR" />
+          <span>Chromatic R scale <output data-out="scaleR">9</output></span>
+          <input type="range" min="0" max="60" step="1" value="9" data-tune="scaleR" />
           <small class="nav-tuner__hint">How far red light is pulled at the rim.</small>
         </label>
         <label data-mode="advanced">
@@ -231,8 +231,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">How far green light is pulled at the rim.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic B scale <output data-out="scaleB">14</output></span>
-          <input type="range" min="0" max="60" step="1" value="14" data-tune="scaleB" />
+          <span>Chromatic B scale <output data-out="scaleB">15</output></span>
+          <input type="range" min="0" max="60" step="1" value="15" data-tune="scaleB" />
           <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens.</small>
         </label>
         <label data-mode="advanced">
@@ -426,21 +426,21 @@ const isDev = import.meta.env.DEV;
           const defaults = {
             // Advanced underlying state
             clamp: 0.97,
-            scaleR: 10,
+            scaleR: 9,
             scaleG: 12,
-            scaleB: 14,
+            scaleB: 15,
             mapBlur: 1.4,
             saturate: 125,
             // Both-mode state
-            sheen: 0.20,
+            sheen: 0.30,
             specularSat: 2.5,
-            backdropBlur: 2.25,
+            backdropBlur: 7,
             progBlur: 0.5,
             glassBg: 0.16,
             // Simplified-mode derived view: center = BASE_CENTER * refractionLevel,
             // R/B = center ∓ chromaticSpread.
             refractionLevel: 1.00,
-            chromaticSpread: 2,
+            chromaticSpread: 3,
           };
           const state = { ...defaults };
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -4,11 +4,105 @@ import ThemeToggle from './ThemeToggle.astro';
 ---
 
 <svg class="liquid-glass-defs" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-  <filter id="liquid-glass-distort" x="-10%" y="-10%" width="120%" height="120%">
-    <feTurbulence type="fractalNoise" baseFrequency="0.018 0.024" numOctaves="2" seed="7" result="noise" />
-    <feDisplacementMap in="SourceGraphic" in2="noise" scale="14" xChannelSelector="R" yChannelSelector="G" />
+  <!--
+    Liquid glass with chromatic aberration. Per Frontend Masters' "Liquid
+    Glass on the Web" pattern (Chromium-only — Safari/Firefox don't chain
+    SVG filters into backdrop-filter and fall back to plain blur+saturate
+    from .glass).
+
+    Pipeline:
+      1. feImage loads the runtime-generated lens displacement map.
+      2. feGaussianBlur smooths the map further to kill stepping artifacts.
+      3. Three feDisplacementMap passes shift R, G, B at slightly different
+         scales — gives chromatic aberration at the rim (rainbow fringe).
+      4. feColorMatrix isolates each channel so we don't double-count.
+      5. feBlend mode="lighten" recombines (per-channel max).
+  -->
+  <filter id="liquid-glass-distort" x="0" y="0" width="100%" height="100%">
+    <feImage id="liquid-glass-map" href="" preserveAspectRatio="none" result="rawMap" />
+    <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
+
+    <feDisplacementMap in="SourceGraphic" in2="map" scale="9"
+                       xChannelSelector="R" yChannelSelector="G" result="dispR" />
+    <feDisplacementMap in="SourceGraphic" in2="map" scale="11"
+                       xChannelSelector="R" yChannelSelector="G" result="dispG" />
+    <feDisplacementMap in="SourceGraphic" in2="map" scale="13"
+                       xChannelSelector="R" yChannelSelector="G" result="dispB" />
+
+    <feColorMatrix in="dispR" type="matrix" result="rOnly" values="
+      1 0 0 0 0
+      0 0 0 0 0
+      0 0 0 0 0
+      0 0 0 1 0" />
+    <feColorMatrix in="dispG" type="matrix" result="gOnly" values="
+      0 0 0 0 0
+      0 1 0 0 0
+      0 0 0 0 0
+      0 0 0 1 0" />
+    <feColorMatrix in="dispB" type="matrix" result="bOnly" values="
+      0 0 0 0 0
+      0 0 0 0 0
+      0 0 1 0 0
+      0 0 0 1 0" />
+
+    <feBlend in="rOnly" in2="gOnly" mode="lighten" result="rg" />
+    <feBlend in="rg" in2="bOnly" mode="lighten" />
   </filter>
 </svg>
+
+<script is:inline>
+  // Generate a pill-shaped lens displacement map at page load and inject it
+  // into the SVG filter. Encodes inward refraction at the rim, no displacement
+  // at the center — simulates real glass curvature.
+  (function () {
+    const W = 512;
+    const H = 96;
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    const img = ctx.createImageData(W, H);
+    const data = img.data;
+
+    // Squircle profile (Apple's preferred curve, per kube.io/blog/liquid-glass-css-svg).
+    // Surface y = ⁴√(1 − (1 − x)⁴) where x = distance-from-edge. Snell's-law
+    // refraction is proportional to the surface slope; in terms of t =
+    // distance-from-center: |dy/dx| = t³ / (1 − t⁴)^¾. Slope diverges at the
+    // rim, so clamp t before the singularity and normalize so the clamped
+    // peak maps to 1.
+    const SQUIRCLE_CLAMP = 0.97;
+    const squircleSlope = (t) => {
+      const tc = Math.min(t, SQUIRCLE_CLAMP);
+      return Math.pow(tc, 3) / Math.pow(1 - Math.pow(tc, 4), 0.75);
+    };
+    const maxSlope = squircleSlope(SQUIRCLE_CLAMP);
+
+    // Vertical-only lens — a wide horizontal pill is best modelled as a
+    // cylindrical lens. R channel stays at 128 (no horizontal shift) so text
+    // passing under the pill doesn't compress horizontally. Only Y refracts.
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const fy = (y / (H - 1)) * 2 - 1;
+        const shiftY = -Math.sign(fy) * (squircleSlope(Math.abs(fy)) / maxSlope);
+
+        const i = (y * W + x) * 4;
+        data[i] = 128;                                // R = 128 (no X shift)
+        data[i + 1] = Math.round(128 + shiftY * 127); // G = Y displacement
+        data[i + 2] = 0;
+        data[i + 3] = 255;
+      }
+    }
+
+    ctx.putImageData(img, 0, 0);
+    const url = canvas.toDataURL('image/png');
+
+    const feImg = document.getElementById('liquid-glass-map');
+    if (feImg) {
+      feImg.setAttribute('href', url);
+      feImg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', url);
+    }
+  })();
+</script>
 
 <nav id="site-nav">
   <div class="nav-shell max-w-4xl mx-auto px-6 md:px-10">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,13 +26,13 @@ const isDev = import.meta.env.DEV;
     <feGaussianBlur in="rawMap" stdDeviation="0.6" result="map" />
 
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="20"
+                       in="SourceGraphic" in2="map" scale="10"
                        xChannelSelector="R" yChannelSelector="G" result="dispR" />
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="22"
+                       in="SourceGraphic" in2="map" scale="12"
                        xChannelSelector="R" yChannelSelector="G" result="dispG" />
     <feDisplacementMap color-interpolation-filters="sRGB"
-                       in="SourceGraphic" in2="map" scale="24"
+                       in="SourceGraphic" in2="map" scale="14"
                        xChannelSelector="R" yChannelSelector="G" result="dispB" />
 
     <feColorMatrix in="dispR" type="matrix" result="rOnly" values="
@@ -181,7 +181,7 @@ const isDev = import.meta.env.DEV;
         <label data-mode="simple">
           <span>Refraction Level <output data-out="refractionLevel">1.00</output></span>
           <input type="range" min="0" max="2" step="0.05" value="1.00" data-tune="refractionLevel" />
-          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock; 0 = no bend; values above ~1.5 may enter the inversion regime (flipped ghost text inside the pill). Use Advanced for full control.</small>
+          <small class="nav-tuner__hint">How strongly the lens bends light. 1 = stock (Apple-subtle); 0 = no bend; 2 = exaggerated. Inversion-safe across the whole slider range at the current scales — push individual chromatic scales high in Advanced to trigger inversion intentionally.</small>
         </label>
         <label data-mode="simple">
           <span>Chromatic Spread <output data-out="chromaticSpread">2</output></span>
@@ -221,18 +221,18 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Where the bending happens. High = sharp rim, mirror-flat middle. Low = soft bowl that bends light all over.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic R scale <output data-out="scaleR">20</output></span>
-          <input type="range" min="0" max="60" step="1" value="20" data-tune="scaleR" />
+          <span>Chromatic R scale <output data-out="scaleR">10</output></span>
+          <input type="range" min="0" max="60" step="1" value="10" data-tune="scaleR" />
           <small class="nav-tuner__hint">How far red light is pulled at the rim.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic G scale <output data-out="scaleG">22</output></span>
-          <input type="range" min="0" max="60" step="1" value="22" data-tune="scaleG" />
+          <span>Chromatic G scale <output data-out="scaleG">12</output></span>
+          <input type="range" min="0" max="60" step="1" value="12" data-tune="scaleG" />
           <small class="nav-tuner__hint">How far green light is pulled at the rim.</small>
         </label>
         <label data-mode="advanced">
-          <span>Chromatic B scale <output data-out="scaleB">24</output></span>
-          <input type="range" min="0" max="60" step="1" value="24" data-tune="scaleB" />
+          <span>Chromatic B scale <output data-out="scaleB">14</output></span>
+          <input type="range" min="0" max="60" step="1" value="14" data-tune="scaleB" />
           <small class="nav-tuner__hint">How far blue light is pulled. Mismatch R/G/B → rainbow halo; match → clean lens.</small>
         </label>
         <label data-mode="advanced">
@@ -402,8 +402,10 @@ const isDev = import.meta.env.DEV;
       (function () {
         // Base chromatic model — Refraction Level (simplified) scales BASE_CENTER,
         // Chromatic Spread (simplified) is the ±offset of R and B from the center.
-        // Defaults: center=22, spread=2 → 20/22/24 (user-tuned visual sweet spot).
-        const BASE_CENTER = 22;
+        // Defaults: center=12, spread=2 → 10/12/14 (Apple-stock subtle: ~6px rim
+        // displacement on the 64px pill, well below the ~32 inversion threshold
+        // across the full 0–2 slider range).
+        const BASE_CENTER = 12;
 
         function setup() {
           const panel = document.getElementById('nav-tuner-panel');
@@ -424,9 +426,9 @@ const isDev = import.meta.env.DEV;
           const defaults = {
             // Advanced underlying state
             clamp: 0.97,
-            scaleR: 20,
-            scaleG: 22,
-            scaleB: 24,
+            scaleR: 10,
+            scaleG: 12,
+            scaleB: 14,
             mapBlur: 1.4,
             saturate: 125,
             // Both-mode state

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,8 +100,12 @@ html.dark {
        outside the SVG filter (vs. prototype's internal feGaussianBlur);
        saturation is pumped hard so refracted colors read vivid. */
     background: rgba(255, 255, 255, 0.06);
-    -webkit-backdrop-filter: blur(7px) saturate(300%) url(#liquid-glass-distort);
-    backdrop-filter: blur(7px) saturate(300%) url(#liquid-glass-distort);
+    /* Saturation now lives inside the SVG filter (feColorMatrix saturate=4)
+       per the Option E mechanism. CSS pre-saturate stays at 100% (no-op);
+       the tuner's "Backdrop saturate" slider can still push it for an
+       extra pre-filter punch if desired. */
+    -webkit-backdrop-filter: blur(7px) saturate(100%) url(#liquid-glass-distort);
+    backdrop-filter: blur(7px) saturate(100%) url(#liquid-glass-distort);
     box-shadow:
       inset 0 0 12px -3px rgba(255, 255, 255, 0.60),  /* soft inner glow */
       0 18px 30px -10px rgba(0, 0, 0, 0.35);           /* lifted drop shadow */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -107,7 +107,7 @@ html.dark {
        the page. Overrides the plain --glass-inner from .glass for the
        desktop nav specifically. */
     box-shadow:
-      inset 0  1px 0 rgba(255, 255, 255, 0.50),  /* top — strong */
+      inset 0  1px 0 rgba(255, 255, 255, 0.65),  /* top — strong, Apple-edge */
       inset 0 -1px 0 rgba(255, 255, 255, 0.22),  /* bottom counter */
       inset  1px 0 0 rgba(255, 255, 255, 0.12),  /* left */
       inset -1px 0 0 rgba(255, 255, 255, 0.12),  /* right */
@@ -116,7 +116,7 @@ html.dark {
 
   html.dark #nav-pill {
     box-shadow:
-      inset 0  1px 0 rgba(255, 255, 255, 0.22),
+      inset 0  1px 0 rgba(255, 255, 255, 0.30),
       inset 0 -1px 0 rgba(255, 255, 255, 0.10),
       inset  1px 0 0 rgba(255, 255, 255, 0.06),
       inset -1px 0 0 rgba(255, 255, 255, 0.06),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,6 +100,27 @@ html.dark {
        saturation so refracted color reads vivid through the glass. */
     -webkit-backdrop-filter: blur(1px) saturate(180%) url(#liquid-glass-distort);
     backdrop-filter: blur(1px) saturate(180%) url(#liquid-glass-distort);
+    /* Full-perimeter specular ring. Apple's pills get the "thick glass"
+       read from a directional bright top-edge plus a dimmer counter-
+       highlight at the bottom and faint side rings. Stacked inset
+       shadows draw the ring; the outer drop shadow lifts the pill off
+       the page. Overrides the plain --glass-inner from .glass for the
+       desktop nav specifically. */
+    box-shadow:
+      inset 0  1px 0 rgba(255, 255, 255, 0.50),  /* top — strong */
+      inset 0 -1px 0 rgba(255, 255, 255, 0.22),  /* bottom counter */
+      inset  1px 0 0 rgba(255, 255, 255, 0.12),  /* left */
+      inset -1px 0 0 rgba(255, 255, 255, 0.12),  /* right */
+      var(--glass-shadow);
+  }
+
+  html.dark #nav-pill {
+    box-shadow:
+      inset 0  1px 0 rgba(255, 255, 255, 0.22),
+      inset 0 -1px 0 rgba(255, 255, 255, 0.10),
+      inset  1px 0 0 rgba(255, 255, 255, 0.06),
+      inset -1px 0 0 rgba(255, 255, 255, 0.06),
+      var(--glass-shadow);
   }
 
   #nav-pill::before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,6 +30,15 @@ body {
   --glow-fade-opaque: rgba(255, 255, 255, 1);
   --glow-fade-transparent: rgba(255, 255, 255, 0);
   --glow-alpha: 0.35;
+
+  /* Liquid-glass refraction tunables — read by Nav.astro's IIFE via
+     getComputedStyle. Edit here, not in JS. Unitless because the IIFE
+     parseFloat()s and uses them as plain numbers. Defaults from
+     github.com/The-Magicians-Code/prototypes/liquid-glass-pill. */
+  --lg-thickness: 80;
+  --lg-bezel: 20;
+  --lg-ior: 1.5;
+  --lg-uniform-shift: 0;
 }
 
 html.dark {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,33 +94,24 @@ html.dark {
   #nav-pill {
     position: relative;
     isolation: isolate;
-    /* Minimal blur + boosted saturation. The SVG filter chain provides
-       lens displacement and chromatic aberration — backdrop-filter's job
-       is just to (a) provide a tiny softening pass and (b) punch the
-       saturation so refracted color reads vivid through the glass. */
-    -webkit-backdrop-filter: blur(1px) saturate(180%) url(#liquid-glass-distort);
-    backdrop-filter: blur(1px) saturate(180%) url(#liquid-glass-distort);
-    /* Full-perimeter specular ring. Apple's pills get the "thick glass"
-       read from a directional bright top-edge plus a dimmer counter-
-       highlight at the bottom and faint side rings. Stacked inset
-       shadows draw the ring; the outer drop shadow lifts the pill off
-       the page. Overrides the plain --glass-inner from .glass for the
-       desktop nav specifically. */
+    /* Pill identity ported from themagicianscode.dev/prototypes/liquid-glass-pill:
+       very transparent panel, soft inner glow (instead of hard 1px rim
+       inset), and a strong lifted drop shadow. Backdrop blur stays
+       outside the SVG filter (vs. prototype's internal feGaussianBlur);
+       saturation is pumped hard so refracted colors read vivid. */
+    background: rgba(255, 255, 255, 0.06);
+    -webkit-backdrop-filter: blur(7px) saturate(300%) url(#liquid-glass-distort);
+    backdrop-filter: blur(7px) saturate(300%) url(#liquid-glass-distort);
     box-shadow:
-      inset 0  1px 0 rgba(255, 255, 255, 0.65),  /* top — strong, Apple-edge */
-      inset 0 -1px 0 rgba(255, 255, 255, 0.22),  /* bottom counter */
-      inset  1px 0 0 rgba(255, 255, 255, 0.12),  /* left */
-      inset -1px 0 0 rgba(255, 255, 255, 0.12),  /* right */
-      var(--glass-shadow);
+      inset 0 0 12px -3px rgba(255, 255, 255, 0.60),  /* soft inner glow */
+      0 18px 30px -10px rgba(0, 0, 0, 0.35);           /* lifted drop shadow */
   }
 
   html.dark #nav-pill {
+    background: rgba(23, 23, 23, 0.06);
     box-shadow:
-      inset 0  1px 0 rgba(255, 255, 255, 0.30),
-      inset 0 -1px 0 rgba(255, 255, 255, 0.10),
-      inset  1px 0 0 rgba(255, 255, 255, 0.06),
-      inset -1px 0 0 rgba(255, 255, 255, 0.06),
-      var(--glass-shadow);
+      inset 0 0 12px -3px rgba(255, 255, 255, 0.30),
+      0 18px 30px -10px rgba(0, 0, 0, 0.55);
   }
 
   #nav-pill::before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,7 +38,7 @@ body {
   --lg-thickness: 80;
   --lg-bezel: 20;
   --lg-ior: 1.5;
-  --lg-uniform-shift: 0;
+  --lg-uniform-shift: -4.5;
 }
 
 html.dark {
@@ -113,8 +113,8 @@ html.dark {
        per the Option E mechanism. CSS pre-saturate stays at 100% (no-op);
        the tuner's "Backdrop saturate" slider can still push it for an
        extra pre-filter punch if desired. */
-    -webkit-backdrop-filter: blur(7px) saturate(100%) url(#liquid-glass-distort);
-    backdrop-filter: blur(7px) saturate(100%) url(#liquid-glass-distort);
+    -webkit-backdrop-filter: blur(4px) saturate(100%) url(#liquid-glass-distort);
+    backdrop-filter: blur(4px) saturate(100%) url(#liquid-glass-distort);
     box-shadow:
       inset 0 0 12px -3px rgba(255, 255, 255, 0.60),  /* soft inner glow */
       0 18px 30px -10px rgba(0, 0, 0, 0.35);           /* lifted drop shadow */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,8 +94,12 @@ html.dark {
   #nav-pill {
     position: relative;
     isolation: isolate;
-    -webkit-backdrop-filter: blur(14px) saturate(180%) url(#liquid-glass-distort);
-    backdrop-filter: blur(14px) saturate(180%) url(#liquid-glass-distort);
+    /* Minimal blur + boosted saturation. The SVG filter chain provides
+       lens displacement and chromatic aberration — backdrop-filter's job
+       is just to (a) provide a tiny softening pass and (b) punch the
+       saturation so refracted color reads vivid through the glass. */
+    -webkit-backdrop-filter: blur(1px) saturate(180%) url(#liquid-glass-distort);
+    backdrop-filter: blur(1px) saturate(180%) url(#liquid-glass-distort);
   }
 
   #nav-pill::before {


### PR DESCRIPTION
## Summary

Replaces the desktop nav pill's static `feTurbulence` noise filter with a physics-based refractive lens, plus a dev-only tuner panel for live parameter tweaking. Final implementation is a wholesale port of [`prototypes/liquid-glass-pill`](https://github.com/The-Magicians-Code/prototypes/tree/main/liquid-glass-pill) — Snell's-law refraction profile, SVG-native specular highlight, runtime canvas-generated displacement maps that re-rasterize on pill resize.

## What ships

**SVG filter chain** (in [`Nav.astro`](src/components/Nav.astro)) — nine primitives matching the prototype:
- `feGaussianBlur` (stdDev=1.5) softens the backdrop
- `feImage` loads the runtime-generated displacement map
- `feDisplacementMap` warps the backdrop in 2D
- `feColorMatrix saturate=4` punches the refracted color
- `feImage` loads the runtime-generated specular highlight
- `feComposite operator=in` masks the saturated lens to the highlight shape
- `feComponentTransfer slope=0.4` fades the raw specular to alpha
- Two `feBlend` passes recombine

**Runtime IIFE** generates both maps based on:
- `--lg-thickness` (default 80) — glass slab thickness in px
- `--lg-bezel` (default 20) — bezel width in px
- `--lg-ior` (default 1.5) — refractive index
- `--lg-uniform-shift` (default 0) — Apple-style tilted-slab shift

`ResizeObserver` re-runs `init()` (debounced 100ms) on pill size change, so mobile/tablet/desktop breakpoints all get a correctly-sized lens automatically.

**Dev tuner panel** (gated by `import.meta.env.DEV`):
- Simplified/Advanced mode toggle
- Live sliders for thickness, bezel, IOR, uniform shift, color punch (saturate values), specular strength (feFuncA slope), backdrop blur, backdrop saturate, glass BG opacity, progressive blur
- Output box with paste-friendly key=value format
- Copy + Reset buttons

**CSS identity** in [`global.css`](src/styles/global.css):
- Pill background `rgba(255,255,255,0.06)` (light) / `rgba(23,23,23,0.06)` (dark)
- Soft inner glow `inset 0 0 12px -3px rgba(255,255,255,0.6)` instead of hard 1px rim
- Lifted drop shadow `0 18px 30px -10px rgba(0,0,0,0.35)`
- `color-interpolation-filters=\"sRGB\"` declared on filter + each primitive (defends against browsers that don't propagate the attribute through inheritance)

## Browser support

Chromium-only for the full refractive lens (only Chromium chains SVG filters into `backdrop-filter`). Safari + Firefox get the plain `blur+saturate` frosted-glass fallback from `.glass`.

## Commits

12 commits trace the iteration: starting from a squircle profile, through chromatic-aberration experiments, the inversion-regime diagnosis at high refraction, mode toggle UX, Option E (single-pass + internal saturate), and finally the wholesale port from the prototype.

## Test plan

- [ ] Open in Chromium — pill should refract content scrolling underneath, with visible rim curl + saturated colors
- [ ] Open in Safari/Firefox — pill should show plain frosted-glass blur (fallback)
- [ ] Resize the viewport (or open mobile breakpoint) — lens should regenerate without blank/torn frames
- [ ] Light + dark mode toggle — both should show the soft inner glow with appropriate alpha
- [ ] In dev (`npm run dev`), the tuner panel renders bottom-right; sliders update the lens live
- [ ] In production (`npm run build`), the tuner panel does not render
- [ ] No console errors on first paint or during scroll

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)