### PR TITLE
Gate lens rasterization behind desktop media query

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -217,9 +217,15 @@ const isDev = import.meta.env.DEV;
       return Number.isFinite(v) ? v : fallback;
     }
 
+    // Lens is only applied at >=641px (the @media gate in global.css).
+    // Below that, the pill drops to plain blur+saturate and the SVG filter
+    // is never used — bail before doing the expensive canvas rasterization.
+    const desktopMQ = window.matchMedia('(min-width: 641px)');
+
     function init() {
       const pill = document.getElementById('nav-pill');
       if (!pill) return;
+      if (!desktopMQ.matches) return;
       try {
         const rect = pill.getBoundingClientRect();
         const w = Math.round(rect.width);
@@ -278,7 +284,23 @@ const isDev = import.meta.env.DEV;
       resizeObserver.observe(pill);
     }
 
-    function start() { init(); observePill(); }
+    function start() {
+      // Skip pill observation on mobile too — when the breakpoint is crossed
+      // upward later, the matchMedia listener below kicks observePill() in.
+      if (!desktopMQ.matches) return;
+      init();
+      observePill();
+    }
+
+    // When the user resizes from mobile → desktop, kick init+observePill in.
+    // Going desktop → mobile, init() bails early; the ResizeObserver keeps
+    // running but the bail is cheap.
+    desktopMQ.addEventListener('change', (e) => {
+      if (e.matches) {
+        init();
+        observePill();
+      }
+    });
 
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', start);


### PR DESCRIPTION
## Summary

Addresses Codex's P2 feedback on PR #2: the lens IIFE was running on every page load + resize regardless of breakpoint, but the SVG filter only applies at `>=641px` (the `@media` gate in [global.css](src/styles/global.css)). Mobile was paying for two full per-pixel canvas rasterizations (displacement + specular maps, ~90k pixels per generation) for nothing.

## Fix

Three guards in [Nav.astro](src/components/Nav.astro)'s IIFE:

1. **`init()` bails early** when `desktopMQ.matches` is false.
2. **`start()` skips `observePill()`** on mobile — so we don't even attach the ResizeObserver until we're at the desktop breakpoint.
3. **`matchMedia('change')` listener** kicks `init()` + `observePill()` back on when the user resizes from mobile up across 641px.

Going desktop → mobile, the existing ResizeObserver keeps firing but `init()` bails on the first line — cheap (function call + matchMedia check + early return).

## Test plan

- [ ] Open in mobile viewport (< 641px) — pill renders the plain frosted-glass fallback, no canvas rasterization in the JS profiler
- [ ] Resize from mobile to desktop — lens kicks in correctly, displacement + specular maps populate
- [ ] Resize back to mobile — lens drops, no console errors
- [ ] Open in desktop viewport — same behavior as before this commit (lens always on)
- [ ] Dev tuner still works on desktop (verify a slider drag re-rasterizes via the existing `navlens:reinit` event)

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)