### PR TITLE
Remove redundant public/CNAME

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-themagicianscode.dev


### PR DESCRIPTION
## Summary

The custom domain (`themagicianscode.dev`) is managed via repo Settings → Pages, which `actions/deploy-pages@v5` reads directly when binding the deployment. The `CNAME` file in `public/` was redundant — it got copied into the build artifact but Pages was already wiring the domain from the Settings UI.

## Test plan

- [x] `npm run build` succeeds; `dist/CNAME` no longer present.
- [ ] Post-merge: confirm `themagicianscode.dev` still resolves after the next deploy (Settings UI handles the binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)