### PR TITLE
Set --lg-uniform-shift default to 0

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -102,8 +102,8 @@ const isDev = import.meta.env.DEV;
           <small class="nav-tuner__hint">Refractive index. 1.0 = no refraction (air); 1.5 = standard glass; 2.4 = diamond. Higher = stronger Snell's-law bend. Drives --lg-ior.</small>
         </label>
         <label data-mode="advanced">
-          <span>Uniform Shift <output data-out="uniformShift">-4.5</output>px</span>
-          <input type="range" min="-10" max="10" step="0.5" value="-4.5" data-tune="uniformShift" />
+          <span>Uniform Shift <output data-out="uniformShift">0</output>px</span>
+          <input type="range" min="-10" max="10" step="0.5" value="0" data-tune="uniformShift" />
           <small class="nav-tuner__hint">Apple-style tilted-slab refraction across the whole pill, on top of the rim curl. 0 = pure rim curl; ±5–10 = visible directional drift. Drives --lg-uniform-shift.</small>
         </label>
         <label data-mode="advanced">
@@ -307,7 +307,7 @@ const isDev = import.meta.env.DEV;
             thickness: 80,
             bezel: 20,
             ior: 1.5,
-            uniformShift: -4.5,
+            uniformShift: 0,
             // SVG-side knobs — direct attribute set
             internalSat: 4,
             specStrength: 0.4,

--- a/src/scripts/liquid-glass.ts
+++ b/src/scripts/liquid-glass.ts
@@ -326,7 +326,7 @@ function initElement(el: Element): void {
   const thickness = readCssNumber(htmlEl, '--lg-thickness', 80);
   const bezelWidth = readCssNumber(htmlEl, '--lg-bezel', 20);
   const ior = readCssNumber(htmlEl, '--lg-ior', 1.5);
-  const uniformShift = readCssNumber(htmlEl, '--lg-uniform-shift', -4.5);
+  const uniformShift = readCssNumber(htmlEl, '--lg-uniform-shift', 0);
   const blur = readCssNumber(htmlEl, '--lg-blur', 4);
   const saturate = readCssNumber(htmlEl, '--lg-saturate', 100);
   const svgSaturate = readCssNumber(htmlEl, '--lg-svg-saturate', 4);

--- a/src/styles/liquid-glass.css
+++ b/src/styles/liquid-glass.css
@@ -6,7 +6,7 @@
   --lg-thickness: 80;
   --lg-bezel: 20;
   --lg-ior: 1.5;
-  --lg-uniform-shift: -4.5;
+  --lg-uniform-shift: 0;
   --lg-blur: 4;
   --lg-saturate: 100;
   --lg-svg-saturate: 4;


### PR DESCRIPTION
## Summary
- Drops the nav pill's Apple-style tilted-slab horizontal drift (`--lg-uniform-shift`) from `-4.5` to `0` in the CSS default, the JS readCssNumber fallback, and the Nav tuner's display value, slider value, and reset state.
- Rim curl remains untouched and is the dominant visual signature of the liquid-glass effect anyway.
- Variable is preserved so individual `.liquid-glass` consumers can opt back in via `style="--lg-uniform-shift: -4.5"` if desired.

## Why
At `-4.5` the inside-bottom of the pill was horizontally offset from page content directly underneath, producing a visible bottom-edge seam (most noticeable when high-contrast content like text/icons sits below the pill). The 4-5px slab tilt was below casual perception in normal use but distracting against text. Zero shift removes the seam without losing the refraction character (rim curl carries the look).

## Test plan
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run build` — clean
- [ ] Manual: load `npm run dev`, scroll page under nav pill, confirm no visible bottom seam against text/buttons
- [ ] Manual: open dev tuner, confirm "Uniform Shift" slider starts at 0 and drives the var

🤖 Generated with [Claude Code](https://claude.com/claude-code)