### PR TITLE
Add docs/Ideas.md — running notes file

### DIFF
--- a/docs/Ideas.md
+++ b/docs/Ideas.md
@@ -1,0 +1,23 @@
+## Ideas
+- Animated SVG Claude in the site
+- Animated different Claude Code text [statuses](https://claude-spinner-verbs.vercel.app)
+- https://tympanus.net/codrops/2026/05/05/reverse-engineering-claude-ais-mascot-animations-with-svg-and-gsap/
+- https://claude.ai/design/p/019e0f0d-e003-7135-83d0-4c0f76aca7fb?file=index.html
+- https://gsap.com/docs/v3/
+- apple rainbow logo
+- https://github.com/hotheadhacker/no-as-a-service
+- [HTML CV to PDF](https://www.reddit.com/r/webdev/comments/1m67e80/comment/n4hk5vk/)
+- https://www.typeui.sh
+- https://glassmorphism-pro.vercel.app
+- https://ui.shadcn.com
+- https://lucide.dev
+- https://animations.dev
+- https://simpleicons.org
+- https://github.com/chenglou/pretext
+- http://chenglou.me/pretext/
+- [CV](https://www.overleaf.com)
+- https://www.agentation.com
+
+### Extras to think about
+- Claude playing radio on schedule?
+- [Weekly survival guide](https://www.reddit.com/r/ClaudeAI/wiki/survivalguideweekly/)


### PR DESCRIPTION
## Summary
Adds a personal idea/inspiration list under `docs/`. Not built into `dist/`, has no effect on the deployed site — just keeps notes alongside the rest of the project's non-built docs.

## Test plan
- [x] File-only change, nothing to verify beyond it being tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)