### PR TITLE
Add reference links to Ideas (Glass, Prompting, Design)

### DIFF
--- a/docs/Ideas.md
+++ b/docs/Ideas.md
@@ -18,6 +18,9 @@
 - [CV](https://www.overleaf.com)
 - https://www.agentation.com
 
+### Design
+- https://emilkowal.ski/ui/7-practical-animation-tips
+
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/
 - https://kube.io/blog/liquid-glass-css-svg/

--- a/docs/Ideas.md
+++ b/docs/Ideas.md
@@ -18,6 +18,13 @@
 - [CV](https://www.overleaf.com)
 - https://www.agentation.com
 
+### Glass
+- https://themagicianscode.dev/prototypes/liquid-glass-pill/
+- https://kube.io/blog/liquid-glass-css-svg/
+
+## Prompting
+- https://thariqs.github.io/html-effectiveness/
+
 ### Extras to think about
 - Claude playing radio on schedule?
 - [Weekly survival guide](https://www.reddit.com/r/ClaudeAI/wiki/survivalguideweekly/)


### PR DESCRIPTION
## Summary
- Adds **Glass** section: links to the liquid-glass pill prototype and the kube.io blog post
- Adds **Prompting** section: HTML effectiveness reference
- Adds **Design** section: Emil Kowalski's 7 practical animation tips

## Test plan
- [ ] Docs-only change — no build impact; no test needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)