### PR TITLE
Skip rim-curl on flat top/bottom pill edges

### DIFF
--- a/docs/Ideas.md
+++ b/docs/Ideas.md
@@ -18,6 +18,9 @@
 - [CV](https://www.overleaf.com)
 - https://www.agentation.com
 
+### Design
+- https://emilkowal.ski/ui/7-practical-animation-tips
+
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/
 - https://kube.io/blog/liquid-glass-css-svg/

--- a/docs/Ideas.md
+++ b/docs/Ideas.md
@@ -18,6 +18,13 @@
 - [CV](https://www.overleaf.com)
 - https://www.agentation.com
 
+### Glass
+- https://themagicianscode.dev/prototypes/liquid-glass-pill/
+- https://kube.io/blog/liquid-glass-css-svg/
+
+## Prompting
+- https://thariqs.github.io/html-effectiveness/
+
 ### Extras to think about
 - Claude playing radio on schedule?
 - [Weekly survival guide](https://www.reddit.com/r/ClaudeAI/wiki/survivalguideweekly/)

--- a/src/scripts/liquid-glass.ts
+++ b/src/scripts/liquid-glass.ts
@@ -133,6 +133,7 @@ function generateDisplacementMap(
       const sampleIdx = Math.min((t * samples) | 0, samples - 1);
       const disp = profile[sampleIdx] || 0;
       const dirX = x / dist;
+      if (dirX === 0) continue;
       const dirY = y / dist;
       const dX = (-dirX * disp) / maxDisp;
       const dY = (-dirY * disp) / maxDisp;


### PR DESCRIPTION
## Summary
- Adds `if (dirX === 0) continue;` guard in Phase 2 of `generateDisplacementMap`
- Pixels on the straight horizontal runs (between the rounded caps) keep their Phase 1 neutral values — no vertical `dY` push from the rim curl
- Rounded end caps retain full Snell's-law refraction as before
- Net effect: pill behaves like a horizontal cylinder lens — optically flat on top/bottom, bending only at the left/right arcs

## Test plan
- [ ] `npm run check` — 0 errors ✓
- [ ] `npm run build` — clean ✓
- [ ] Visual check in browser on Chromium (liquid-glass active) and Safari (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)