### PR TITLE
Simplify bento body reveal: single wrap-level fade

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -525,20 +525,18 @@
        above the wrap stay centered via the parent .card-body rule. */
     text-align: left;
   }
-  :global(.bento-card .body-para.appended) {
+  /* .body-para is a structural marker (margins between paragraphs and
+     list items). The fade is now driven by the wrap's existing
+     opacity transition + .is-swapping class — same pattern as the
+     TL;DR ↔ Detailed mode swap. No per-paragraph stagger. */
+  :global(.bento-card .body-para) {
     margin: 14px 0;
-    opacity: 0;
-    transition: opacity 280ms ease;
   }
-  :global(.bento-card .body-para.appended.in) {
-    opacity: 1;
-    transition-delay: calc(var(--stagger-idx, 0) * 80ms);
-  }
-  :global(.bento-card.is-collapsing .body-para.appended),
-  :global(.bento-card.is-collapsing .body-para.appended.in) {
+  /* Close: fade the wrap (parent) — child paragraphs go invisible via
+     parent opacity. Matches the close-fade timing for the body content. */
+  :global(.bento-card.is-collapsing .bento-card-body-rendered) {
     opacity: 0;
     transition: opacity 180ms ease;
-    transition-delay: 0ms;
   }
   /* Markdown body styling — rendered content may carry headings, lists, code, links. */
   :global(.bento-card .bento-card-body-rendered :is(h2, h3)) {
@@ -708,12 +706,11 @@
   :global(.cs-mode-toggle button[aria-selected="true"]) {
     color: var(--ink);
   }
-  /* Fade the pill out alongside the body paragraphs during the close
-     morph. The toggle is a sibling of the rendered wrap (not a child),
-     so it doesn't inherit the .body-para.appended fade rule that
-     handles the rest of the content. Without this, the pill stays at
-     full opacity through the entire shrink and only disappears
-     abruptly at cleanup. Duration matches .is-collapsing .body-para. */
+  /* Fade the pill out alongside the body wrap during the close morph.
+     The toggle is a sibling of the rendered wrap (not a child), so it
+     doesn't inherit the wrap-level opacity fade. Without this, the
+     pill stays at full opacity through the entire shrink and only
+     disappears abruptly at cleanup. Duration matches the wrap fade. */
   :global(.bento-card.is-collapsing .cs-mode-toggle) {
     opacity: 0;
     pointer-events: none;

--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -299,8 +299,10 @@ function doOpen(card: HTMLElement): void {
   };
 
   // After the morph lands, clone the hidden body content into the visible
-  // card-body and fade it in with a per-paragraph stagger. Guard against
-  // close-during-open: if user esc'd before this fires, drop it.
+  // card-body and fade it in. Single wrap-level opacity transition (no
+  // per-paragraph stagger) — same pattern as the TL;DR ↔ Detailed mode
+  // swap (.is-swapping on the wrap → opacity 0 → 1 over 160ms). Guard
+  // against close-during-open: if user esc'd before this fires, drop it.
   window.setTimeout(() => {
     if (!openState || openState.closing) return;
     const body = card.querySelector<HTMLElement>('.card-body');
@@ -308,7 +310,7 @@ function doOpen(card: HTMLElement): void {
     if (!body || !source) return;
 
     const wrap = document.createElement('div');
-    wrap.className = 'bento-card-body-rendered';
+    wrap.className = 'bento-card-body-rendered is-swapping';
     const initialMode = readMode();
     applyMode(wrap, initialMode);
     // Clone children so the original hidden source stays intact for a
@@ -336,14 +338,15 @@ function doOpen(card: HTMLElement): void {
       wrap.appendChild(footer);
     }
 
-    // Per-child stagger via inline custom property.
-    [...wrap.children].forEach((el, idx) => {
-      (el as HTMLElement).style.setProperty('--stagger-idx', String(idx));
-      (el as HTMLElement).classList.add('body-para', 'appended');
-    });
+    // Children keep .body-para for paragraph-structural CSS (margins,
+    // list-item formatting). The fade is now driven by the wrap's
+    // .is-swapping class via the existing opacity transition rule.
+    for (const child of wrap.children) {
+      (child as HTMLElement).classList.add('body-para');
+    }
     void wrap.offsetHeight;
     requestAnimationFrame(() => {
-      [...wrap.children].forEach((el) => el.classList.add('in'));
+      wrap.classList.remove('is-swapping');
     });
   }, MORPH_DUR);
 


### PR DESCRIPTION
## Summary

Replace the per-paragraph staggered fade-in on bento modal body content with a single wrap-level opacity transition — same 160ms fade pattern as the TL;DR ↔ Detailed mode swap.

- **[bento-expand.ts](src/scripts/bento-expand.ts):** wrap mounts with `.is-swapping` (opacity 0), RAF removes the class, the existing CSS transition fades it to 1.
- **[BentoGrid.astro](src/components/BentoGrid.astro):** drop the `.body-para.appended` + `.body-para.appended.in` + `--stagger-idx` rules. `.body-para` stays as a structural class for paragraph margins / list spacing. Close-side fade moves to the wrap (`.is-collapsing .bento-card-body-rendered { opacity: 0 }`).

Net diff: ~25 lines added/removed across two files.

## Test plan

- [x] `npm run check` — 0 errors.
- [x] Chrome: open → wrap mounts at opacity 0.24 mid-transition, settles to 1 at ~800ms. Close → wrap fades to 0 over 180ms.
- [x] Mode toggle still uses its own `.is-swapping` transition path (unaffected — same class, separate trigger).
- [ ] **Safari macOS** — verify clean single fade, no flash or jank.
- [ ] **iOS Safari** — same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)