### PR TITLE
Tone down bento expand/close buttons in dark mode

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -282,6 +282,17 @@
     opacity: 1; transform: scale(1); pointer-events: auto;
   }
   :global(.cs-expand:hover) { background: rgba(255, 255, 255, 0.78); }
+  /* Dark-mode: a bright white disc on dark paper reads as a glaring
+     high-contrast spot. Swap to a low-alpha white tint so the disc
+     stays visible as a glassy lift without burning a hole in the card. */
+  :global(html.dark .cs-expand) {
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.20),
+      0 2px 8px rgba(0, 0, 0, 0.20),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  }
+  :global(html.dark .cs-expand:hover) { background: rgba(255, 255, 255, 0.16); }
   @media (prefers-reduced-motion: reduce) {
     :global(.cs-expand) { transform: none; transition: opacity 200ms ease; }
   }
@@ -790,6 +801,15 @@
   }
   :global(.cs-close:hover) { background: rgba(255, 255, 255, 0.82); }
   :global(.cs-close svg) { width: 16px; height: 16px; }
+  /* Dark-mode parity with .cs-expand — same rationale. */
+  :global(html.dark .cs-close) {
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.24),
+      0 2px 10px rgba(0, 0, 0, 0.24),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+  }
+  :global(html.dark .cs-close:hover) { background: rgba(255, 255, 255, 0.18); }
 
   /* ── Backdrop ─────────────────────────────────────────────────── */
   .bento-backdrop {

--- a/src/components/BentoStackCard.astro
+++ b/src/components/BentoStackCard.astro
@@ -229,7 +229,10 @@
     color: var(--accent);
   }
 
-  /* Hover-revealed expand affordance + close button repainted for paper. */
+  /* Hover-revealed expand affordance + close button repainted for paper.
+     Dark-mode flips the ink-tint to a white tint so the disc stays
+     readable against dark paper (the dark-ink override would otherwise
+     blend into the card). */
   :global(.bento-card.stack-card .cs-expand) {
     background: rgba(26, 26, 28, 0.06);
     color: var(--ink);
@@ -244,5 +247,13 @@
   }
   :global(.bento-card.stack-card .cs-close:hover) {
     background: rgba(26, 26, 28, 0.12);
+  }
+  :global(html.dark .bento-card.stack-card .cs-expand),
+  :global(html.dark .bento-card.stack-card .cs-close) {
+    background: rgba(255, 255, 255, 0.08);
+  }
+  :global(html.dark .bento-card.stack-card .cs-expand:hover),
+  :global(html.dark .bento-card.stack-card .cs-close:hover) {
+    background: rgba(255, 255, 255, 0.16);
   }
 </style>


### PR DESCRIPTION
## Summary
- `.cs-expand` and `.cs-close` discs read as bright high-contrast spots in dark mode (hardcoded white-tinted glass at 0.55–0.6 alpha).
- Stack-card variant had the inverse problem — its dark-ink-tint override designed for cream paper went invisible against dark paper.
- Adds `html.dark` overrides for both default and stack-card discs: low-alpha white tint (0.08 / 0.16–0.18 hover), slightly stronger drop shadows to compensate for dark paper absorbing them.

## Test plan
- [ ] Light mode unchanged: hover a project card → `.cs-expand` reads as warm white glass; click into a card → `.cs-close` reads the same.
- [ ] Dark mode: same flow → discs visible but no longer glaring.
- [ ] Stack card in dark mode: `.cs-expand` and `.cs-close` visible (not blended into the dark card).
- [ ] Reduced motion respected (existing behavior, not modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)