### PR TITLE
Render every blockquote + H2 in TL;DR mode

### DIFF
--- a/docs/superpowers/specs/2026-05-19-case-study-dual-mode-design.md
+++ b/docs/superpowers/specs/2026-05-19-case-study-dual-mode-design.md
@@ -58,18 +58,24 @@ a fixed three-element pattern per section:
    Problem → Approach → Results) but the heading text is freely worded
    ("The problem", "The rebuild", "What changed", etc.).
 2. **A plain blockquote (`>`)** as the first child of each section. This is
-   the section's TL;DR — 1–2 sentences, ~25–40 words.
+   the section's leading TL;DR — 1–2 sentences, ~25–40 words. **Additional
+   blockquotes anywhere inside the section** are treated the same way —
+   each becomes another TL;DR bullet visible in TL;DR mode. Use them when
+   a section's skim deserves more than one beat.
 3. **Everything else under the heading** is the Detail prose — paragraphs,
-   lists, code, links, all standard Markdown.
+   lists, code, links, all standard Markdown. None of it shows in TL;DR.
 
 Example skeleton:
 
 ```markdown
 ## The problem
 
-> One- or two-sentence summary with a number in it.
+> One- or two-sentence leading summary with a number in it.
 
 Detailed paragraph or two of the why, the what-broke, the symptoms.
+
+> An optional second TL;DR bullet that captures a separate beat —
+> e.g. the secondary failure mode, or the constraint that made it hard.
 
 Another paragraph with more depth.
 ```
@@ -124,10 +130,16 @@ of the section's content follows as sibling elements. We use CSS sibling
 combinators to gate visibility based on the body's `data-mode`:
 
 ```css
-/* In TL;DR mode: keep the H2 and its first blockquote visible; hide
-   every sibling that follows the blockquote until the next H2. */
+/* In TL;DR mode: hide every sibling that follows the section-leading
+   blockquote — including subsequent H2s, which the broad `~ *` also
+   catches — then unhide H2s and blockquotes so the scannable spine
+   (heading + 1+ bullets per section) renders. */
 .bento-card-body-rendered[data-mode="tldr"] h2 + blockquote ~ * {
   display: none;
+}
+.bento-card-body-rendered[data-mode="tldr"] h2 + blockquote ~ h2,
+.bento-card-body-rendered[data-mode="tldr"] h2 + blockquote ~ blockquote {
+  display: block;
 }
 /* In Detailed mode: render the first blockquote styled as a lede. */
 .bento-card-body-rendered[data-mode="detailed"] h2 + blockquote {
@@ -139,10 +151,12 @@ combinators to gate visibility based on the body's `data-mode`:
 }
 ```
 
-The CSS uses `h2 + blockquote ~ *` to hide everything that follows the
-section-leading blockquote in TL;DR mode. H2s themselves stay visible in both
-modes (they're scannable structure). The next H2 inside the same wrap remains
-visible because it's matched by its own `h2 + blockquote` rule.
+The CSS uses `h2 + blockquote ~ *` as a broad hide that sweeps every
+sibling following the leading blockquote of the first section. That
+includes subsequent H2s and blockquotes, so two follow-up rules
+reinstate them. The net visibility in TL;DR mode: H2s + blockquotes
+render (section heading + one or more bullets); everything else is
+hidden until the reader switches to Detailed.
 
 **Edge case:** if a section is missing the leading blockquote, the
 `h2 + blockquote` selector doesn't match and that section's content stays

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -598,11 +598,21 @@
   :global(.bento-card-body-rendered.is-swapping) {
     opacity: 0;
   }
-  /* Hide everything that follows the section-leading blockquote in TL;DR
-     mode. The next H2 reopens its own section's leading blockquote
-     because the selector is scoped by the blockquote's sibling chain. */
+  /* Authoring contract in TL;DR mode: H2s + blockquotes are always
+     visible (the scannable spine of the case study). Blockquotes are
+     TL;DR bullets (one or more per section); every other sibling
+     between H2s is Detailed-only elaboration.
+
+     The broad `~ *` hide sweeps non-quote prose AND subsequent H2s
+     (the selector matches every sibling after the first
+     `h2 + blockquote` pair, regardless of tag). Two unhide rules
+     reinstate the spine: H2s and blockquotes both stay rendered. */
   :global(.bento-card-body-rendered[data-mode="tldr"] h2 + blockquote ~ *) {
     display: none;
+  }
+  :global(.bento-card-body-rendered[data-mode="tldr"] h2 + blockquote ~ h2),
+  :global(.bento-card-body-rendered[data-mode="tldr"] h2 + blockquote ~ blockquote) {
+    display: block;
   }
   /* Style the section-leading blockquote as an italic lede in Detailed
      mode so it reads as the section's nut graph rather than a generic
@@ -616,10 +626,10 @@
     font-size: 15px;
     line-height: 1.55;
   }
-  /* In TL;DR mode, the leading blockquote IS the content for the
-     section — drop the indent + bar styling so it reads as a normal
-     paragraph under the heading. */
-  :global(.bento-card-body-rendered[data-mode="tldr"] h2 + blockquote) {
+  /* In TL;DR mode every blockquote is a TL;DR point — drop the indent +
+     bar styling so all of them read as normal paragraphs under the
+     heading, not browser-default italic-indented quotation blocks. */
+  :global(.bento-card-body-rendered[data-mode="tldr"] blockquote) {
     border-left: none;
     padding: 0;
     margin: 0 0 14px;


### PR DESCRIPTION
## Summary
- TL;DR mode now renders the full scannable spine of each case study: every H2 heading + every blockquote in the section. Previously only the first H2 and its leading blockquote were visible — every subsequent heading was clobbered by the broad `h2 + blockquote ~ *` hide rule (a pre-existing bug; spec claimed H2s stayed visible but the selector matched them).
- Authoring contract shifts: blockquotes are TL;DR bullets (1+ per section), not a single leading summary. Add a `>` anywhere inside a section to surface another beat in TL;DR.
- TL;DR blockquote-styling generalized from leading-only to all blockquotes so follow-up bullets render as plain paragraphs, not browser-default italic-indented quote blocks.
- Spec doc ([2026-05-19-case-study-dual-mode-design.md](docs/superpowers/specs/2026-05-19-case-study-dual-mode-design.md)) updated.

No content changes — current project files have one blockquote per section, so this lands as a no-op visually until a section adds a second `>` bullet.

## Test plan
- [ ] Open any project card in TL;DR mode → all four section headings (Context / Problem / Approach / Results) visible with their bullets, no orphan paragraphs.
- [ ] Switch to Detailed → unchanged from before.
- [ ] Switch back to TL;DR → fade-swap clean, scroll resets to top.
- [ ] Manually add a second `>` bullet inside one section's detail prose locally → it renders in TL;DR as a sibling bullet under the heading; in Detailed it renders as a default browser blockquote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)