### PR TITLE
Add performance.dev to design inspiration links

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -44,6 +44,7 @@
 - https://developers.openai.com/blog/designing-delightful-frontends-with-gpt-5-4
 - https://appstacks.club/mobile-apps
 - https://www.landing.love/categories/portfolio/
+- https://performance.dev
 
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/


### PR DESCRIPTION
## Summary
- Adds `https://performance.dev` to the Design section of `docs/ideas/Ideas.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)