### PR TITLE
Add references and Performance section to ideas backlog

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -44,7 +44,8 @@
 - https://developers.openai.com/blog/designing-delightful-frontends-with-gpt-5-4
 - https://appstacks.club/mobile-apps
 - https://www.landing.love/categories/portfolio/
-- https://performance.dev
+- https://www.stainless.com
+- https://www.interfacecraft.dev
 
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/
@@ -63,3 +64,5 @@
 - WebGPU or WebGL
 - Web Animaions API
 - https://performance.dev/how-is-linear-so-fast-a-technical-breakdown
+- https://www.npmjs.com/package/html-in-canvas-polyfill
+- https://performance.dev

--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -58,3 +58,8 @@
 - [Weekly survival guide](https://www.reddit.com/r/ClaudeAI/wiki/survivalguideweekly/)
 - Edge-blur / mask-fade on case-study titles (desktop only?) — alternative to text wrapping where the title stays on one line and the right edge fades to transparent via `mask-image: linear-gradient(...)`. Container width changes during open/close simply reveal more of the same text (no reflow, no word-flip, no Pretext needed). Trade-off: mobile users lose information at the tile level since there's less screen real estate to begin with, so this likely needs to be desktop-only or disabled under a viewport-width media query. Could pair with `backdrop-filter: blur(...)` on a right-edge pseudo-element for an actual progressive blur instead of just opacity fade.
 - In each project box extended content: "For all the nerds out there, this one's for you", with the detailed or "extravagant" button with deepwiki links
+
+### Performance
+- WebGPU or WebGL
+- Web Animaions API
+- https://performance.dev/how-is-linear-so-fast-a-technical-breakdown


### PR DESCRIPTION
## Summary
- Add a **Performance** subsection to `docs/ideas/Ideas.md` covering WebGPU/WebGL, Web Animations API, and the performance.dev Linear writeup
- Add new design references (stainless.com, interfacecraft.dev) and a html-in-canvas-polyfill link
- Move `performance.dev` from the Design list into Performance where it belongs

Backlog-only — no code paths touched.

## Test plan
- [ ] `docs/ideas/Ideas.md` renders correctly on GitHub
- [ ] No build or content-collection impact (file lives outside `src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)