### PR TITLE
Add more references to ideas backlog (follow-up)

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -46,6 +46,8 @@
 - https://www.landing.love/categories/portfolio/
 - https://www.stainless.com
 - https://www.interfacecraft.dev
+- https://interfaces.dev
+- https://cofounder.co
 
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/
@@ -56,6 +58,7 @@
 
 ### Extras to think about
 - Claude playing radio on schedule?
+- https://andonlabs.com/radio
 - [Weekly survival guide](https://www.reddit.com/r/ClaudeAI/wiki/survivalguideweekly/)
 - Edge-blur / mask-fade on case-study titles (desktop only?) — alternative to text wrapping where the title stays on one line and the right edge fades to transparent via `mask-image: linear-gradient(...)`. Container width changes during open/close simply reveal more of the same text (no reflow, no word-flip, no Pretext needed). Trade-off: mobile users lose information at the tile level since there's less screen real estate to begin with, so this likely needs to be desktop-only or disabled under a viewport-width media query. Could pair with `backdrop-filter: blur(...)` on a right-edge pseudo-element for an actual progressive blur instead of just opacity fade.
 - In each project box extended content: "For all the nerds out there, this one's for you", with the detailed or "extravagant" button with deepwiki links


### PR DESCRIPTION
## Summary
- Add interfaces.dev and cofounder.co to the Design references
- Add andonlabs.com/radio next to the existing "Claude playing radio on schedule?" idea

Follow-up to #20. Backlog-only — no code paths touched.

## Test plan
- [ ] `docs/ideas/Ideas.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)