### PR TITLE
Add more design references to ideas backlog

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -48,6 +48,8 @@
 - https://www.interfacecraft.dev
 - https://interfaces.dev
 - https://cofounder.co
+- https://www.hover.dev
+- https://gridportfolio.sites.blink.new
 
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/


### PR DESCRIPTION
## Summary
- Adds hover.dev and gridportfolio.sites.blink.new to the Design references list

Follow-up to #20 and #21. Backlog-only — no code paths touched.

## Test plan
- [ ] \`docs/ideas/Ideas.md\` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)