### PR TITLE
Land expand content-blur with the box morph

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -1126,10 +1126,13 @@
     /* filter is LINEAR (not the front-loaded ease-out) so the un-blur spreads
        over the whole duration — text resolves into focus gradually rather than
        snapping sharp in the first ~300ms, mirroring how the close stays soft. */
+    /* Reveal runs for the box-morph duration (not --content-dur) so the
+       content finishes resolving exactly when the box lands. The close exit
+       keeps --content-dur (its own rule below) for the slower fade-out. */
     transition:
-      opacity var(--content-dur) linear,
-      filter var(--content-dur) linear,
-      transform var(--content-dur) var(--fade-ease);
+      opacity var(--morph-dur) linear,
+      filter var(--morph-dur) linear,
+      transform var(--morph-dur) var(--fade-ease);
   }
   /* Modal title: centered ink (overrides base rest-y transform, the
      fit-content width, and the is-expanded center-x transform). */


### PR DESCRIPTION
Small choreography tweak: on expand, the content blur-in now finishes exactly when the box finishes morphing.

Previously the reveal ran for `--content-dur` (1000ms) while the box morph is `--morph-dur` (760ms) — both start together at the 180ms frost-first mark, so the text kept sharpening for ~240ms after the box had already settled. The reveal now uses `--morph-dur`, so it lands with the box.

The close exit is unchanged (keeps `--content-dur` for its slower fade-out); the frost-first hold is intact.

Verified in Chromium: box hits full width ~900ms and the title reaches full opacity ~940ms (was trailing to ~1180ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)