### PR TITLE
Link the BSc thesis source on yolo-dualdev

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -50,6 +50,7 @@
 - https://cofounder.co
 - https://www.hover.dev
 - https://gridportfolio.sites.blink.new
+- https://rauno.me
 
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/
@@ -73,3 +74,8 @@
 - https://performance.dev/how-is-linear-so-fast-a-technical-breakdown
 - https://www.npmjs.com/package/html-in-canvas-polyfill
 - https://performance.dev
+
+### Courses
+- https://devouringdetails.com
+- https://animations.dev
+- https://motion.dev

--- a/src/content/projects/yolo-dualdev.md
+++ b/src/content/projects/yolo-dualdev.md
@@ -12,7 +12,7 @@ draft: false
 
 ## Context
 
-> A 2023 bachelor's thesis at TalTech: a real-time computer-vision system that gives an autonomous Baltic Workboats Navy 18 WP patrol vessel the situational awareness it needs to run its own sea trials.
+> A 2023 <a href="https://digikogu.taltech.ee/et/Item/d72f8d4b-6c21-4e6c-b2a4-b71484c55d0b" target="_blank" rel="noopener noreferrer">bachelor's thesis</a> at TalTech: a real-time computer-vision system that gives an autonomous Baltic Workboats Navy 18 WP patrol vessel the situational awareness it needs to run its own sea trials.
 
 A joint project between TalTech's Department of Electrical Power Engineering and Mechatronics, the TalTech Small Boat Competence Center, and Baltic Workboats. The goal was to automate *käigukatsed* — vessel speed and maneuverability sea trials — that had traditionally required a human captain to run the boat manually while a second person logged readings on paper. Different captains meant inconsistent inputs; manual logging meant inconsistent data. Removing the captain from the loop needed a vessel that could see what was around it. The thesis built the perception layer: an embedded computer-vision system mounted in the boat's forward control mast, fused with the existing x-band radar, AIS, and wind sensor, feeding object detections to the autopilot. Solo implementation, mentored on hardware + hypothesis by Heigo Mõlder (PhD) and Karl Janson (PhD).
 


### PR DESCRIPTION
Adds the canonical thesis source — the TalTech digikogu record — to the **Vision pipeline for edge inference** case study.

Linked on "bachelor's thesis" in the **Context** blockquote, which is visible in both TL;DR and Detailed modes. Opens in a new tab (`target="_blank" rel="noopener noreferrer"`), styled by the existing `.bento-card-body-rendered a` rule (accent + underline).

URL: https://digikogu.taltech.ee/et/Item/d72f8d4b-6c21-4e6c-b2a4-b71484c55d0b

Verified the anchor is present and correct in the built output (homepage card body + detail page). Note: Astro's content layer cached it on the running dev server, so a local `npm run dev` restart is needed to preview locally — the build/deploy is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)