### PR TITLE
Polish nav theme toggle and hamburger animations

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -38,7 +38,6 @@ const isDev = import.meta.env.DEV;
             <div class="hamburger-lines" aria-hidden="true">
               <span class="line line1"></span>
               <span class="line line2"></span>
-              <span class="line line3"></span>
             </div>
           </button>
         </div>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -7,6 +7,78 @@ import { Icon } from 'astro-icon/components';
   <Icon name="lucide:moon" class="icon-moon" aria-hidden="true" />
 </button>
 
+<style is:global>
+  #theme-toggle-button {
+    position: relative;
+    width: 36px;
+    height: 36px;
+    border-radius: 9999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-dim);
+    transition: color 0.2s ease, background-color 0.2s ease, transform 0.15s ease-out;
+    line-height: 0;
+    cursor: pointer;
+  }
+
+  #theme-toggle-button:hover {
+    color: var(--ink);
+    background-color: rgba(128, 128, 128, .15);
+  }
+
+  /* Subtle press dip — feels responsive, animations.dev copy-button style. */
+  #theme-toggle-button:active {
+    transform: scale(0.97);
+  }
+
+  /* Both icons stay rendered, stacked on top of each other, so the theme
+     swap can cross-fade instead of hard-swapping via display:none. */
+  #theme-toggle-button .icon-sun,
+  #theme-toggle-button .icon-moon {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 20px;
+    height: 20px;
+    transition: opacity 0.15s ease-out, transform 0.15s ease-out, filter 0.15s ease-out;
+  }
+
+  /* Inactive icon: blurred + shrunk + transparent. The blur blends the two
+     states together so the swap reads as a smooth melt rather than a cut. */
+  #theme-toggle-button .icon-moon {
+    opacity: 0;
+    transform: scale(0.6);
+    filter: blur(2px);
+  }
+  #theme-toggle-button .icon-sun {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+  }
+  html.dark #theme-toggle-button .icon-sun {
+    opacity: 0;
+    transform: scale(0.6);
+    filter: blur(2px);
+  }
+  html.dark #theme-toggle-button .icon-moon {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #theme-toggle-button,
+    #theme-toggle-button .icon-sun,
+    #theme-toggle-button .icon-moon {
+      transition: none;
+    }
+    #theme-toggle-button:active {
+      transform: none;
+    }
+  }
+</style>
+
 <script>
   const THEME_KEY = 'theme-preference';
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -365,34 +365,7 @@ body.bento-open .nav-progressive-blur {
   gap: 0.25rem;
 }
 
-#theme-toggle-button {
-  width: 36px;
-  height: 36px;
-  border-radius: 9999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--ink-dim);
-  transition: color 0.2s ease, background-color 0.2s ease;
-  line-height: 0;
-  cursor: pointer;
-}
-
-#theme-toggle-button:hover {
-  color: var(--ink);
-  background-color: rgba(128, 128, 128, .15);
-}
-
-#theme-toggle-button .icon-moon { display: none; }
-#theme-toggle-button .icon-sun  { display: inline-block; }
-html.dark #theme-toggle-button .icon-moon { display: inline-block; }
-html.dark #theme-toggle-button .icon-sun  { display: none; }
-
-#theme-toggle-button > svg,
-#theme-toggle-button > i > svg {
-  width: 20px;
-  height: 20px;
-}
+/* #theme-toggle-button styles live in src/components/ThemeToggle.astro */
 
 .hamburger-button {
   width: 44px;
@@ -419,13 +392,17 @@ html.dark #theme-toggle-button .icon-sun  { display: none; }
   width: 100%;
   background-color: currentColor;
   border-radius: 1px;
-  transition: transform 0.3s ease-in-out, opacity 0.2s ease-in-out;
   transform-origin: center;
+  /* Closing: un-rotate to flat first, then slide back apart. */
+  transition: rotate 0.15s ease-in-out, translate 0.15s ease-in-out 0.15s;
 }
 
-.hamburger-button.open .line1 { transform: translateY(8px) rotate(45deg); }
-.hamburger-button.open .line2 { opacity: 0; transform: scaleX(0); }
-.hamburger-button.open .line3 { transform: translateY(-8px) rotate(-45deg); }
+/* Opening: slide together vertically (staying parallel) first, then rotate into the X. */
+.hamburger-button.open .line {
+  transition: translate 0.15s ease-in-out, rotate 0.15s ease-in-out 0.15s;
+}
+.hamburger-button.open .line1 { translate: 0 6px; rotate: 45deg; }
+.hamburger-button.open .line2 { translate: 0 -6px; rotate: -45deg; }
 
 /* ===== Mobile Menu Panel ===== */
 #mobile-menu {


### PR DESCRIPTION
## What

Two nav micro-interaction upgrades.

**Theme toggle** (animations.dev copy-button style)
- Stacked sun/moon icons instead of `display:none` swap, so the theme change **cross-fades** via `blur(2px)` + `scale(0.6→1)` + opacity at `0.15s ease-out`.
- `scale(0.97)` press dip for responsiveness.
- `prefers-reduced-motion` guard.
- Moved the `#theme-toggle-button` block out of `global.css` into `ThemeToggle.astro` (`<style is:global>`) to keep it self-contained.

**Hamburger**
- Reduced to **two stripes**.
- Staged morph using separate `translate`/`rotate` properties with offset `transition-delay`: bars slide together vertically (parallel) → then rotate into the X. Reverse on close.

## Verification
- `npm run check` — 0 errors / 0 warnings
- `npm run build` — clean, 6 pages
- Visual: build-only so far; the `filter: blur` cross-fade and staged hamburger are worth an eyeball in Chromium + Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)