### PR TITLE
Add ⌘K command palette prototype (spotlight + terminal, no React)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ The nav pill's refraction effect is the most non-obvious system in the repo. It'
 
 **Design context:** [docs/superpowers/specs/2026-05-08-liquid-glass-module-design.md](docs/superpowers/specs/2026-05-08-liquid-glass-module-design.md) captures the architectural decisions, the codex-rescue review findings that shaped the spec (the original `var(--lg-filter, none)` chain was invalid CSS that would have dropped the whole declaration), explicit non-goals (no dynamic-mount support, no per-element filter cleanup on DOM removal), and acceptance criteria. Read this before refactoring the module.
 
-**Nav-specific tuner:** [src/components/Nav.astro](src/components/Nav.astro) renders a sliders panel inside `{isDev && (...)}` (only in `import.meta.env.DEV`). It writes the eight module CSS vars to `#nav-pill`'s inline style and calls `window.__lg.refresh(pill)`, plus mutates two nav-only knobs (`glassBg`, `progBlur`) that the module itself doesn't know about.
+**Nav-specific tuner:** [src/components/Nav.astro](src/components/Nav.astro) renders a sliders panel inside `{isDev && (...)}` (only in `import.meta.env.DEV`). It writes the eight module CSS vars to `#nav-pill`'s inline style and calls `window.__lg.refresh(pill)`, plus mutates two nav-only knobs (`glassBg`, `progBlur`) that the module itself doesn't know about. The panel is **hidden by default** even in dev — summon it with `⌘/Ctrl+Shift+G` (visibility persists in `localStorage` under `navTunerVisible`) or force it open with `#tuner`/`?tuner` in the URL. Showing it auto-expands the body; the in-panel `+/−` button still collapses to a header.
 
 ## Content Collections
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,17 @@
+# Netlify config — used for per-PR Deploy Previews.
+# Production stays on GitHub Pages (themagicianscode.dev) via
+# .github/workflows/deploy.yml. Netlify never serves the custom domain (we
+# don't point DNS at it), so its build is only ever reached through the
+# *.netlify.app preview URLs.
+#
+# One-time setup: connect this repo at app.netlify.com (Add new site → Import
+# an existing project → GitHub → pick this repo). Netlify auto-detects this
+# file. With the Netlify GitHub App installed, every PR gets a Deploy Preview
+# URL posted as a check. No secrets are stored in the repo.
+
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
-# Netlify config — used for per-PR Deploy Previews.
+# Netlify config — used for per-PR Deploy Previews and per-branch deploys.
 # Production stays on GitHub Pages (themagicianscode.dev) via
 # .github/workflows/deploy.yml. Netlify never serves the custom domain (we
 # don't point DNS at it), so its build is only ever reached through the
@@ -8,6 +8,10 @@
 # an existing project → GitHub → pick this repo). Netlify auto-detects this
 # file. With the Netlify GitHub App installed, every PR gets a Deploy Preview
 # URL posted as a check. No secrets are stored in the repo.
+#
+# To get a URL for every non-main branch, set "Branch deploys" to "All" in the
+# Netlify UI (Site configuration → Build & deploy → Branches and deploy
+# contexts). main is the production branch and is skipped below.
 
 [build]
   command = "npm run build"
@@ -15,3 +19,11 @@
 
 [build.environment]
   NODE_VERSION = "20"
+
+# main is already live on GitHub Pages, so don't waste a Netlify production
+# build on it. `ignore` exiting 0 tells Netlify "nothing to build" → the
+# production deploy is skipped. Deploy Previews and branch deploys are
+# separate contexts and still build normally.
+[context.production]
+  ignore = "exit 0"
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,8 @@
   publish = "dist"
 
 [build.environment]
-  NODE_VERSION = "20"
+  # Astro 6 requires Node >=22.12.0 (see astro engines field); 20 fails the build.
+  NODE_VERSION = "22"
 
 # main is already live on GitHub Pages, so don't waste a Netlify production
 # build on it. `ignore` exiting 0 tells Netlify "nothing to build" → the

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -23,6 +23,21 @@ const projects = (await getCollection('projects'))
   .filter((p) => !p.data.draft)
   .sort((a, b) => a.data.order - b.data.order);
 
+// Flatten a project's Markdown body to plain text so `grep`/`cat` can search
+// the full detail page, not just the frontmatter description (the detail route
+// renders the same body via <Content />).
+function mdToText(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links → text
+    .replace(/^[>#\-*+\s]+/gm, ' ') // leading md punctuation
+    .replace(/[*_~`#>]/g, ' ') // inline md punctuation
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 const languages = resume.skills.find((s) => s.label === 'Languages')?.items ?? [];
 const allSkills = resume.skills.map((g) => `${g.label}: ${g.items.join(', ')}`).join(' · ');
 const email = resume.contact[0].label;
@@ -39,7 +54,7 @@ interface PaletteEntry {
   subtitle?: string;
   keywords?: string[];
   body?: string; // plain-text used by `cat` / `grep`
-  action: 'navigate' | 'open-url' | 'copy-email' | 'toggle-theme' | 'print';
+  action: 'navigate' | 'open-url' | 'copy-email' | 'toggle-theme';
   href?: string;
 }
 
@@ -60,7 +75,7 @@ const entries: PaletteEntry[] = [
     title: titleToText(p.data.title),
     subtitle: p.data.description,
     keywords: ['project', 'repo', p.id],
-    body: p.data.description,
+    body: `${p.data.description} ${mdToText(p.body ?? '')}`.trim(),
     action: 'navigate' as const,
     href: `/projects/${p.id}/`,
   })),
@@ -184,13 +199,20 @@ const meta = {
   </div>
 </div>
 
-<script type="application/json" id="cmdk-data" is:inline set:html={JSON.stringify({ entries, meta })} />
+<script
+  type="application/json"
+  id="cmdk-data"
+  is:inline
+  set:html={JSON.stringify({ entries, meta }).replace(/</g, '\\u003c')}
+/>
 
 <style>
   .cmdk-root {
     position: fixed;
     inset: 0;
-    z-index: 120;
+    /* Above the bento case-study modal (backdrop 200 / card 201) so ⌘K never
+       opens the palette hidden behind an open case study. */
+    z-index: 300;
     display: grid;
     grid-template-rows: 1fr;
     justify-items: center;
@@ -199,8 +221,12 @@ const meta = {
   }
   .cmdk-root[hidden] { display: none; }
 
-  /* Scrollbars are hidden globally, so locking scroll causes no layout shift. */
+  /* Scroll lock. Scrollbars are hidden globally so there's no layout shift,
+     but global.css sets html{overflow-x:clip} which makes <html> the real
+     scroller — so body{overflow:hidden} alone won't stop the background from
+     scrolling. Lock html too, matching the bento modal precedent. */
   :global(body.cmdk-open) { overflow: hidden; }
+  :global(html:has(body.cmdk-open)) { overflow-y: hidden; }
 
   .cmdk-overlay {
     position: fixed;

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -230,8 +230,8 @@ const meta = {
      but global.css sets html{overflow-x:clip} which makes <html> the real
      scroller — so body{overflow:hidden} alone won't stop the background from
      scrolling. Lock html too, matching the bento modal precedent. */
-  :global(body.cmdk-open) { overflow: hidden; }
-  :global(html:has(body.cmdk-open)) { overflow-y: hidden; }
+  body.cmdk-open { overflow: hidden; }
+  html:has(body.cmdk-open) { overflow-y: hidden; }
 
   .cmdk-overlay {
     position: fixed;
@@ -263,7 +263,7 @@ const meta = {
 
   /* The liquid-glass upgrade applies its own translucent backdrop on Chromium;
      keep a near-opaque paper tint underneath so text stays legible. */
-  :global(html.lg-no-svg-backdrop) .cmdk-dialog,
+  html.lg-no-svg-backdrop .cmdk-dialog,
   .cmdk-dialog { background: color-mix(in oklab, var(--paper) 94%, transparent); }
 
   .cmdk-input-row {

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -240,7 +240,7 @@ const meta = {
     -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
     opacity: 0;
-    transition: opacity 0.2s var(--ease);
+    transition: opacity 0.26s var(--ease);
   }
   .cmdk-root.is-open .cmdk-overlay { opacity: 1; }
 
@@ -257,7 +257,7 @@ const meta = {
     overflow: hidden;
     transform: translateY(-8px) scale(0.985);
     opacity: 0;
-    transition: opacity 0.2s var(--ease), transform 0.2s var(--ease);
+    transition: opacity 0.26s var(--ease), transform 0.26s var(--ease);
   }
   .cmdk-root.is-open .cmdk-dialog { transform: none; opacity: 1; }
 

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -1,0 +1,418 @@
+---
+/**
+ * Command palette ("⌘K") — prototype.
+ *
+ * A dependency-free spotlight + terminal hybrid. The markup + a serialized
+ * content index are rendered server-side here; all behaviour lives in the
+ * vanilla-TS module src/scripts/command-palette.ts (no React, no hydration —
+ * matching the liquid-glass module pattern).
+ *
+ * Two modes share one input:
+ *  - Spotlight: fuzzy-filter a registry of navigation targets, content
+ *    "answers" (skills, hobbies, email…), and actions (copy email, toggle
+ *    theme…). Arrow keys + Enter.
+ *  - Terminal: when the query starts with a known command (ls, cat, grep,
+ *    whoami, open, theme, ask…) the body becomes a shell transcript that
+ *    greps/cats the same content index.
+ */
+import { getCollection } from 'astro:content';
+import { resume } from '../data/resume';
+import { titleToText } from '../lib/title';
+
+const projects = (await getCollection('projects'))
+  .filter((p) => !p.data.draft)
+  .sort((a, b) => a.data.order - b.data.order);
+
+const languages = resume.skills.find((s) => s.label === 'Languages')?.items ?? [];
+const allSkills = resume.skills.map((g) => `${g.label}: ${g.items.join(', ')}`).join(' · ');
+const email = resume.contact[0].label;
+const github = 'https://github.com/The-Magicians-Code';
+const linkedin = 'https://www.linkedin.com/in/taneltreuberg/';
+
+// Flat, JSON-serializable registry the client script consumes. Each entry is
+// searchable (title + subtitle + keywords + body) and carries an action.
+interface PaletteEntry {
+  id: string;
+  group: string;
+  icon: string; // lucide name fragment (rendered as inline SVG below via sprite map)
+  title: string;
+  subtitle?: string;
+  keywords?: string[];
+  body?: string; // plain-text used by `cat` / `grep`
+  action: 'navigate' | 'open-url' | 'copy-email' | 'toggle-theme' | 'print';
+  href?: string;
+}
+
+const entries: PaletteEntry[] = [
+  // ---- Navigation ----
+  { id: 'home', group: 'Navigate', icon: 'home', title: 'Home', subtitle: 'Top of the page', keywords: ['start', 'top'], action: 'navigate', href: '/' },
+  { id: 'about', group: 'Navigate', icon: 'user', title: 'About', subtitle: 'A short introduction', keywords: ['intro', 'bio', 'who'], body: resume.summary, action: 'navigate', href: '/#about' },
+  { id: 'work', group: 'Navigate', icon: 'folder', title: 'Work', subtitle: 'Selected projects', keywords: ['projects', 'portfolio', 'case studies'], action: 'navigate', href: '/#projects' },
+  { id: 'stack', group: 'Navigate', icon: 'layers', title: 'Stack', subtitle: 'Skills & tools', keywords: ['skills', 'tools', 'tech', 'technologies'], body: allSkills, action: 'navigate', href: '/#skills-tools' },
+  { id: 'resume', group: 'Navigate', icon: 'file', title: 'Résumé', subtitle: 'Full CV', keywords: ['cv', 'experience', 'work history'], action: 'navigate', href: '/resume/' },
+  { id: 'contact', group: 'Navigate', icon: 'mail', title: 'Contact', subtitle: 'Get in touch', keywords: ['email', 'reach', 'hire'], action: 'navigate', href: '/#contact' },
+
+  // ---- Projects (detail pages) ----
+  ...projects.map((p) => ({
+    id: `project-${p.id}`,
+    group: 'Projects',
+    icon: 'box',
+    title: titleToText(p.data.title),
+    subtitle: p.data.description,
+    keywords: ['project', 'repo', p.id],
+    body: p.data.description,
+    action: 'navigate' as const,
+    href: `/projects/${p.id}/`,
+  })),
+
+  // ---- Answers (content the script can show inline / cat) ----
+  {
+    id: 'ans-whoami',
+    group: 'Answers',
+    icon: 'sparkles',
+    title: 'Who is Tanel?',
+    subtitle: `${resume.title} · ${resume.baseLocation.city}, ${resume.baseLocation.country}`,
+    keywords: ['whoami', 'name', 'role', 'title', 'location', 'based'],
+    body: `${resume.name} — ${resume.title}, based in ${resume.baseLocation.city}, ${resume.baseLocation.country}. ${resume.summary}`,
+    action: 'navigate',
+    href: '/#about',
+  },
+  {
+    id: 'ans-skills',
+    group: 'Answers',
+    icon: 'layers',
+    title: 'Skills & tools',
+    subtitle: allSkills,
+    keywords: ['skills', 'tech', 'tools', 'stack', 'technologies'],
+    body: resume.skills.map((g) => `${g.label}: ${g.items.join(', ')}`).join('\n'),
+    action: 'navigate',
+    href: '/#skills-tools',
+  },
+  {
+    id: 'ans-languages',
+    group: 'Answers',
+    icon: 'code',
+    title: 'Programming languages',
+    subtitle: languages.join(', '),
+    keywords: ['languages', 'programming', 'python', 'code'],
+    body: `Languages: ${languages.join(', ')}.`,
+    action: 'navigate',
+    href: '/#skills-tools',
+  },
+  {
+    id: 'ans-interests',
+    group: 'Answers',
+    icon: 'heart',
+    title: 'Hobbies & interests',
+    subtitle: resume.interests,
+    keywords: ['hobbies', 'interests', 'fun', 'dancing', 'music', 'guitar', 'piano', 'tango', 'zouk'],
+    body: resume.interests ?? '',
+    action: 'navigate',
+    href: '/resume/',
+  },
+  {
+    id: 'ans-experience',
+    group: 'Answers',
+    icon: 'briefcase',
+    title: 'Experience',
+    subtitle: resume.experience.map((e) => e.company).join(' · '),
+    keywords: ['experience', 'jobs', 'roles', 'career', 'work history'],
+    body: resume.experience
+      .map((e) => `${e.role} @ ${e.company} (${e.dates.display}) — ${e.tagline ?? ''}`)
+      .join('\n'),
+    action: 'navigate',
+    href: '/resume/',
+  },
+
+  // ---- Actions ----
+  { id: 'act-email', group: 'Actions', icon: 'copy', title: 'Copy email address', subtitle: email, keywords: ['email', 'copy', 'mail'], body: email, action: 'copy-email' },
+  { id: 'act-mailto', group: 'Actions', icon: 'mail', title: 'Send an email', subtitle: email, keywords: ['email', 'write', 'contact'], action: 'open-url', href: `mailto:${email}` },
+  { id: 'act-github', group: 'Actions', icon: 'github', title: 'Open GitHub', subtitle: 'github.com/The-Magicians-Code', keywords: ['github', 'code', 'repos', 'source'], action: 'open-url', href: github },
+  { id: 'act-linkedin', group: 'Actions', icon: 'linkedin', title: 'Open LinkedIn', subtitle: 'linkedin.com/in/taneltreuberg', keywords: ['linkedin', 'social', 'connect'], action: 'open-url', href: linkedin },
+  { id: 'act-theme', group: 'Actions', icon: 'contrast', title: 'Toggle theme', subtitle: 'Switch light / dark', keywords: ['theme', 'dark', 'light', 'mode', 'sol', 'lua'], action: 'toggle-theme' },
+  { id: 'act-print', group: 'Actions', icon: 'printer', title: 'Print / download résumé', subtitle: 'Opens the CV, then print', keywords: ['print', 'pdf', 'download', 'cv', 'resume'], action: 'navigate', href: '/resume/' },
+];
+
+const meta = {
+  name: resume.name,
+  title: resume.title,
+  location: `${resume.baseLocation.city}, ${resume.baseLocation.country}`,
+  email,
+};
+---
+
+<div id="cmdk-root" class="cmdk-root" hidden>
+  <div class="cmdk-overlay" data-cmdk-overlay></div>
+  <div
+    class="cmdk-dialog liquid-glass"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Command palette"
+    data-lg-mobile
+  >
+    <div class="cmdk-input-row">
+      <span class="cmdk-prompt" data-cmdk-prompt aria-hidden="true">
+        <!-- search glyph (spotlight) / $ (terminal), swapped by JS -->
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
+      </span>
+      <input
+        id="cmdk-input"
+        type="text"
+        class="cmdk-input"
+        placeholder="Search, or type a command (try: help)…"
+        autocomplete="off"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        aria-label="Search or run a command"
+        aria-controls="cmdk-list"
+        aria-expanded="true"
+      />
+      <span class="cmdk-mode" data-cmdk-mode hidden>TERM</span>
+      <kbd class="cmdk-esc">esc</kbd>
+    </div>
+
+    <div id="cmdk-list" class="cmdk-body" role="listbox" aria-label="Results"></div>
+
+    <div class="cmdk-footer">
+      <span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+      <span><kbd>↵</kbd> select</span>
+      <span><kbd>esc</kbd> close</span>
+      <span class="cmdk-footer-spacer"></span>
+      <span class="cmdk-hint">Type <kbd>help</kbd> for commands</span>
+    </div>
+  </div>
+</div>
+
+<script type="application/json" id="cmdk-data" is:inline set:html={JSON.stringify({ entries, meta })} />
+
+<style>
+  .cmdk-root {
+    position: fixed;
+    inset: 0;
+    z-index: 120;
+    display: grid;
+    grid-template-rows: 1fr;
+    justify-items: center;
+    align-items: start;
+    padding: clamp(56px, 12vh, 160px) 16px 16px;
+  }
+  .cmdk-root[hidden] { display: none; }
+
+  /* Scrollbars are hidden globally, so locking scroll causes no layout shift. */
+  :global(body.cmdk-open) { overflow: hidden; }
+
+  .cmdk-overlay {
+    position: fixed;
+    inset: 0;
+    background: color-mix(in oklab, var(--bg) 55%, transparent);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+    opacity: 0;
+    transition: opacity 0.2s var(--ease);
+  }
+  .cmdk-root.is-open .cmdk-overlay { opacity: 1; }
+
+  .cmdk-dialog {
+    position: relative;
+    width: min(620px, 100%);
+    max-height: min(70vh, 640px);
+    display: flex;
+    flex-direction: column;
+    background: var(--paper);
+    border: 1px solid var(--glass-brd);
+    border-radius: 16px;
+    box-shadow: var(--glass-shadow), 0 40px 80px -32px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+    transform: translateY(-8px) scale(0.985);
+    opacity: 0;
+    transition: opacity 0.2s var(--ease), transform 0.2s var(--ease);
+  }
+  .cmdk-root.is-open .cmdk-dialog { transform: none; opacity: 1; }
+
+  /* The liquid-glass upgrade applies its own translucent backdrop on Chromium;
+     keep a near-opaque paper tint underneath so text stays legible. */
+  :global(html.lg-no-svg-backdrop) .cmdk-dialog,
+  .cmdk-dialog { background: color-mix(in oklab, var(--paper) 94%, transparent); }
+
+  .cmdk-input-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .cmdk-prompt {
+    display: inline-flex;
+    color: var(--ink-3);
+    flex: none;
+    width: 18px;
+  }
+  .cmdk-root.is-terminal .cmdk-prompt {
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-weight: 600;
+    align-items: center;
+  }
+  .cmdk-input {
+    flex: 1;
+    border: 0;
+    background: transparent;
+    color: var(--ink);
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1.4;
+    outline: none;
+    min-width: 0;
+  }
+  .cmdk-root.is-terminal .cmdk-input { font-family: var(--font-mono); }
+  .cmdk-input::placeholder { color: var(--ink-3); }
+
+  .cmdk-mode {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+    border: 1px solid var(--accent-soft);
+    background: var(--accent-soft);
+    border-radius: 5px;
+    padding: 2px 6px;
+    flex: none;
+  }
+  .cmdk-mode[hidden] { display: none; }
+
+  .cmdk-esc {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--ink-3);
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    padding: 2px 6px;
+    flex: none;
+  }
+
+  .cmdk-body {
+    overflow-y: auto;
+    padding: 8px;
+    flex: 1;
+    min-height: 0;
+  }
+
+  /* ----- Spotlight list ----- */
+  .cmdk-group-label {
+    font-size: 10.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    padding: 10px 10px 4px;
+  }
+  .cmdk-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 9px 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    color: var(--ink);
+    scroll-margin: 8px;
+  }
+  .cmdk-item[aria-selected='true'] { background: var(--accent-soft); }
+  .cmdk-item-icon {
+    flex: none;
+    display: inline-flex;
+    color: var(--ink-dim);
+  }
+  .cmdk-item[aria-selected='true'] .cmdk-item-icon { color: var(--accent); }
+  .cmdk-item-text { min-width: 0; flex: 1; }
+  .cmdk-item-title {
+    font-size: 0.92rem;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cmdk-item-title mark {
+    background: transparent;
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .cmdk-item-sub {
+    font-size: 0.78rem;
+    color: var(--ink-3);
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cmdk-item-go {
+    flex: none;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--ink-3);
+    opacity: 0;
+  }
+  .cmdk-item[aria-selected='true'] .cmdk-item-go { opacity: 1; }
+
+  .cmdk-empty {
+    padding: 28px 16px;
+    text-align: center;
+    color: var(--ink-3);
+    font-size: 0.9rem;
+  }
+  .cmdk-empty code {
+    color: var(--accent);
+    font-family: var(--font-mono);
+  }
+
+  /* ----- Terminal ----- */
+  .cmdk-term {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.55;
+    padding: 6px 8px 4px;
+    color: var(--ink-dim);
+  }
+  .cmdk-term-line { white-space: pre-wrap; word-break: break-word; }
+  .cmdk-term-cmd { color: var(--ink); }
+  .cmdk-term-cmd::before { content: '$ '; color: var(--accent); }
+  .cmdk-term mark {
+    background: var(--accent-soft);
+    color: var(--accent);
+    border-radius: 3px;
+    padding: 0 1px;
+  }
+  .cmdk-term-path { color: var(--ink-3); }
+  .cmdk-term-key { color: var(--accent); }
+  .cmdk-term-muted { color: var(--ink-3); }
+  .cmdk-term-run {
+    color: var(--ink-3);
+    margin-top: 6px;
+  }
+  .cmdk-term-run kbd { color: var(--accent); }
+
+  .cmdk-footer {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 9px 14px;
+    border-top: 1px solid var(--rule);
+    font-size: 11px;
+    color: var(--ink-3);
+  }
+  .cmdk-footer-spacer { flex: 1; }
+  .cmdk-footer .cmdk-hint { white-space: nowrap; }
+  .cmdk-footer kbd,
+  .cmdk-term-run kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    padding: 1px 5px;
+    margin: 0 1px;
+    color: var(--ink-dim);
+  }
+  @media (max-width: 520px) {
+    .cmdk-footer .cmdk-hint,
+    .cmdk-footer-spacer { display: none; }
+  }
+</style>

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -206,7 +206,12 @@ const meta = {
   set:html={JSON.stringify({ entries, meta }).replace(/</g, '\\u003c')}
 />
 
-<style>
+<!-- is:global is required: the result rows, group labels and terminal lines are
+     injected at runtime via innerHTML in command-palette.ts, so they never
+     receive Astro's scoped-style attribute. Scoped CSS would only reach the
+     server-rendered chrome (dialog/input/footer), leaving the dynamic rows
+     unstyled. All selectors here are .cmdk-* namespaced, so global is safe. -->
+<style is:global>
   .cmdk-root {
     position: fixed;
     inset: 0;

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,6 +26,18 @@ const isDev = import.meta.env.DEV;
       <div class="flex-1"></div>
       <div class="side-wrap actions-wrap">
         <div class="nav-actions">
+          <button
+            id="cmdk-trigger"
+            type="button"
+            class="cmdk-trigger"
+            data-cmdk-open
+            aria-label="Open command palette"
+            aria-keyshortcuts="Meta+K Control+K"
+          >
+            <Icon name="lucide:search" class="cmdk-trigger-icon" aria-hidden="true" />
+            <span class="cmdk-trigger-label">Search</span>
+            <kbd class="cmdk-trigger-kbd" aria-hidden="true">⌘K</kbd>
+          </button>
           <ThemeToggle />
           <button
             id="hamburger-button"
@@ -45,6 +57,50 @@ const isDev = import.meta.env.DEV;
     </div>
   </div>
 </nav>
+
+<style>
+  /* Command-palette trigger — sits with the nav actions. Reads as a quiet
+     search affordance with a keyboard hint; collapses to an icon on mobile. */
+  .cmdk-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 34px;
+    padding: 0 10px;
+    border-radius: 999px;
+    border: 1px solid var(--rule);
+    background: color-mix(in oklab, var(--ink) 4%, transparent);
+    color: var(--ink-dim);
+    font-family: var(--font-sans);
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+  }
+  .cmdk-trigger:hover {
+    color: var(--ink);
+    border-color: color-mix(in oklab, var(--ink) 22%, transparent);
+  }
+  .cmdk-trigger-icon {
+    width: 16px;
+    height: 16px;
+    flex: none;
+  }
+  .cmdk-trigger-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    line-height: 1;
+    padding: 3px 5px;
+    border-radius: 5px;
+    border: 1px solid var(--rule);
+    color: var(--ink-3);
+  }
+  /* Below the desktop breakpoint, show just the magnifier icon. */
+  @media (max-width: 640px) {
+    .cmdk-trigger { padding: 0; width: 34px; justify-content: center; }
+    .cmdk-trigger-label,
+    .cmdk-trigger-kbd { display: none; }
+  }
+</style>
 
 <script>
   // When the Home brand is clicked AND we're already on the home page,

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -494,9 +494,9 @@ const isDev = import.meta.env.DEV;
               ev.target.textContent = 'Copied ✓';
               setTimeout(() => { ev.target.textContent = 'Copy values'; }, 1200);
             } catch {
-              const ta = document.getElementById('nav-tuner-output');
-              ta.select();
-              document.execCommand('copy');
+              // Clipboard API blocked (rare; dev-only tool). Select the output
+              // so it can be copied manually with ⌘/Ctrl+C.
+              document.getElementById('nav-tuner-output').select();
             }
           });
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -123,7 +123,7 @@ const isDev = import.meta.env.DEV;
   <Fragment>
     <div class="nav-progressive-blur" aria-hidden="true" data-scroll-lock-compensate></div>
 
-    <aside id="nav-tuner-panel" class="nav-tuner mode-simple collapsed" aria-label="Liquid glass tuner" data-scroll-lock-compensate>
+    <aside id="nav-tuner-panel" class="nav-tuner mode-simple collapsed is-hidden" aria-label="Liquid glass tuner" data-scroll-lock-compensate>
       <header class="nav-tuner__head">
         <span>Nav glass tuner</span>
         <button type="button" id="nav-tuner-toggle" aria-label="Expand tuner">+</button>
@@ -234,6 +234,8 @@ const isDev = import.meta.env.DEV;
         gap: 10px;
       }
       .nav-tuner.collapsed .nav-tuner__body { display: none; }
+      /* Hidden until summoned with ⌘/Ctrl+Shift+G (or #tuner in the URL). */
+      .nav-tuner.is-hidden { display: none; }
       .nav-tuner label {
         display: flex;
         flex-direction: column;
@@ -508,11 +510,45 @@ const isDev = import.meta.env.DEV;
             apply();
           });
 
-          document.getElementById('nav-tuner-toggle').addEventListener('click', (ev) => {
+          const collapseBtn = document.getElementById('nav-tuner-toggle');
+          collapseBtn.addEventListener('click', (ev) => {
             const collapsed = panel.classList.toggle('collapsed');
             ev.target.textContent = collapsed ? '+' : '−';
             ev.target.setAttribute('aria-label', collapsed ? 'Expand tuner' : 'Collapse tuner');
           });
+
+          // Hidden by default; summon with ⌘/Ctrl+Shift+G (state persisted),
+          // or force it open with #tuner / ?tuner in the URL.
+          const VISIBLE_KEY = 'navTunerVisible';
+          function setVisible(visible, persist = true) {
+            panel.classList.toggle('is-hidden', !visible);
+            if (visible) {
+              // Open ready-to-use rather than as a bare collapsed header.
+              panel.classList.remove('collapsed');
+              collapseBtn.textContent = '−';
+              collapseBtn.setAttribute('aria-label', 'Collapse tuner');
+            }
+            if (persist) {
+              try { localStorage.setItem(VISIBLE_KEY, visible ? '1' : '0'); } catch {}
+            }
+          }
+
+          let storedVisible = null;
+          try { storedVisible = localStorage.getItem(VISIBLE_KEY); } catch {}
+          const forcedOpen = location.hash === '#tuner'
+            || new URLSearchParams(location.search).has('tuner');
+          setVisible(forcedOpen || storedVisible === '1', false);
+
+          window.addEventListener('keydown', (ev) => {
+            if ((ev.metaKey || ev.ctrlKey) && ev.shiftKey && (ev.key === 'g' || ev.key === 'G')) {
+              ev.preventDefault();
+              setVisible(panel.classList.contains('is-hidden'));
+            }
+          });
+
+          if (import.meta.env.DEV) {
+            console.info('[nav-tuner] hidden — press ⌘/Ctrl+Shift+G to toggle (or add #tuner to the URL).');
+          }
 
           pushCssVars();
           apply();

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -100,6 +100,19 @@ import { Icon } from 'astro-icon/components';
     filter: blur(0);
   }
 
+  /* Mobile: icon-only. The labelled ("Sol"/"Lua") variant is destined for the
+     dropdown menu, where text beside the icon reads well; in the compact nav we
+     drop the label and collapse the pill to a square icon button. */
+  @media (max-width: 640px) {
+    #theme-toggle-button {
+      width: 36px;
+      padding: 0;
+      gap: 0;
+      justify-content: center;
+    }
+    #theme-toggle-button .tt-label { display: none; }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     #theme-toggle-button,
     #theme-toggle-button .icon-sun,

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -114,13 +114,8 @@ import { Icon } from 'astro-icon/components';
 </style>
 
 <script>
-  const THEME_KEY = 'theme-preference';
-
-  const handleClick = () => {
-    const isDark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem(THEME_KEY, isDark ? 'dark' : 'light');
-  };
+  import { applyTheme } from '../lib/theme';
 
   const button = document.getElementById('theme-toggle-button');
-  button?.addEventListener('click', handleClick);
+  button?.addEventListener('click', () => applyTheme('toggle'));
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import '../styles/liquid-glass.css';
 import Nav from '../components/Nav.astro';
 import MobileMenu from '../components/MobileMenu.astro';
 import SiteFooter from '../components/SiteFooter.astro';
+import CommandPalette from '../components/CommandPalette.astro';
 
 interface Props {
   title: string;
@@ -119,6 +120,10 @@ const personSchema = {
     </script>
 
     <script>
+      import '../scripts/command-palette';
+    </script>
+
+    <script>
       // Dev-only element picker. The `import.meta.env.DEV` guard is a Vite
       // build-time constant, so the dynamic import is dead-code-eliminated in
       // production and `pick-mode` never enters the prod bundle graph.
@@ -132,5 +137,6 @@ const personSchema = {
     <MobileMenu />
     <slot />
     <SiteFooter />
+    <CommandPalette />
   </body>
 </html>

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,26 @@
+// Single source of truth for runtime theme switching. Both the nav's
+// ThemeToggle button and the command palette drive the theme through here so
+// the persisted value and the applied `html.dark` class can't diverge.
+//
+// Note: BaseLayout's pre-paint <script is:inline> deliberately does NOT import
+// this — it must run before any module loads (to avoid a flash of the wrong
+// theme) and inline scripts can't use imports. It only reads THEME_KEY; keep
+// the key string in sync if it ever changes.
+
+export const THEME_KEY = 'theme-preference';
+
+export type ThemeMode = 'dark' | 'light' | 'toggle';
+
+/**
+ * Apply a theme to <html>, persist the choice, and return whether dark mode is
+ * now active. `'toggle'` flips the current state; `'dark'`/`'light'` set it.
+ */
+export function applyTheme(mode: ThemeMode = 'toggle'): boolean {
+  const root = document.documentElement;
+  const isDark = mode === 'toggle' ? !root.classList.contains('dark') : mode === 'dark';
+  root.classList.toggle('dark', isDark);
+  try {
+    localStorage.setItem(THEME_KEY, isDark ? 'dark' : 'light');
+  } catch {}
+  return isDark;
+}

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -432,11 +432,8 @@ function init() {
 
   input.addEventListener('keydown', (e) => {
     const terminal = isTerminal(input.value);
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      close();
-      return;
-    }
+    // Esc is handled by the document-level listener (see below) so it works
+    // even when focus isn't on the input.
     // Focus trap: the input is the only focusable control in the dialog, so
     // Tab/Shift+Tab would otherwise escape to the nav/page behind the overlay.
     if (e.key === 'Tab') {
@@ -511,6 +508,10 @@ function init() {
       const idx = Number(item.dataset.idx);
       const entry = visible[idx];
       if (entry) runAction(entry);
+      // For actions that keep the palette open (e.g. theme toggle), the click
+      // may have moved focus off the input; restore it so keyboard nav and the
+      // Esc/Tab handlers keep working.
+      if (!root!.hidden) input.focus();
     }
   });
 
@@ -526,6 +527,15 @@ function init() {
 
   // Global hotkeys: ⌘K / Ctrl+K toggles; "/" opens when not already typing.
   document.addEventListener('keydown', (e) => {
+    // Esc closes whenever the palette is open. Handled at the document level
+    // (not just on the input) so it still works after an in-palette action that
+    // keeps the dialog open but moves focus off the input — e.g. clicking the
+    // theme toggle, which in some engines blurs focus to <body>.
+    if (e.key === 'Escape' && !root!.hidden) {
+      e.preventDefault();
+      close();
+      return;
+    }
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault();
       toggle();

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -10,6 +10,8 @@
  * becomes a shell transcript that operates over the same index.
  */
 
+import { applyTheme } from '../lib/theme';
+
 interface PaletteEntry {
   id: string;
   group: string;
@@ -39,7 +41,6 @@ declare global {
   }
 }
 
-const THEME_KEY = 'theme-preference';
 const COMMANDS = ['help', 'ls', 'cat', 'grep', 'whoami', 'open', 'theme', 'email', 'clear', 'ask'];
 
 // Minimal inline-SVG sprite (lucide path data). The client module injects
@@ -357,10 +358,11 @@ function init() {
 
       case 'theme': {
         const mode = arg.toLowerCase();
-        if (!preview) applyTheme(mode === 'dark' || mode === 'light' ? mode : 'toggle');
-        // After applyTheme, html.dark reflects the *new* state — report it as-is.
-        const now = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
-        return line('', `theme → <span class="cmdk-term-key">${preview ? (mode || 'toggle') : now}</span>`);
+        const requested = mode === 'dark' || mode === 'light' ? mode : 'toggle';
+        // applyTheme returns the resulting state, so we report exactly what was
+        // applied (in preview we just echo the requested mode).
+        const label = preview ? mode || 'toggle' : applyTheme(requested) ? 'dark' : 'light';
+        return line('', `theme → <span class="cmdk-term-key">${label}</span>`);
       }
 
       case 'email':
@@ -401,15 +403,6 @@ function init() {
   }
 
   // ----- actions -----
-  function applyTheme(mode: 'dark' | 'light' | 'toggle') {
-    const html = document.documentElement;
-    const dark = mode === 'toggle' ? !html.classList.contains('dark') : mode === 'dark';
-    html.classList.toggle('dark', dark);
-    try {
-      localStorage.setItem(THEME_KEY, dark ? 'dark' : 'light');
-    } catch {}
-  }
-
   function copyEmail() {
     navigator.clipboard?.writeText(meta.email).catch(() => {});
   }

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -517,6 +517,23 @@ function init() {
 
   overlay?.addEventListener('click', close);
 
+  // iOS touch-scroll guard. The CSS lock (body.cmdk-open{overflow:hidden} +
+  // html:has(...)) stops wheel/keyboard scroll, but iOS Safari lets touch and
+  // momentum scrolling bleed through overflow:hidden on the background. Block
+  // touchmove while the palette is open, except inside the scrollable results
+  // list so it can still be flicked. Non-passive so preventDefault() works.
+  // (Deliberately not position:fixed — see CLAUDE.md, that broke scroll
+  // position twice on iOS.)
+  document.addEventListener(
+    'touchmove',
+    (e) => {
+      if (root!.hidden) return;
+      if (list && list.contains(e.target as Node)) return; // allow list scroll
+      e.preventDefault();
+    },
+    { passive: false },
+  );
+
   // Belt-and-suspenders focus trap: if focus escapes the open dialog (e.g. a
   // programmatic move), pull it back to the input.
   document.addEventListener('focusin', (e) => {

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -1,0 +1,534 @@
+/**
+ * Command palette runtime — prototype.
+ *
+ * Dependency-free (no React/cmdk). Mirrors the liquid-glass module pattern:
+ * auto-wires on DOMContentLoaded, reads a server-rendered JSON index, and
+ * publishes an imperative handle on `window.__cmdk`.
+ *
+ * Spotlight mode: fuzzy-filter the entry registry.
+ * Terminal mode: when the query's first token is a known command, the body
+ * becomes a shell transcript that operates over the same index.
+ */
+
+interface PaletteEntry {
+  id: string;
+  group: string;
+  icon: string;
+  title: string;
+  subtitle?: string;
+  keywords?: string[];
+  body?: string;
+  action: 'navigate' | 'open-url' | 'copy-email' | 'toggle-theme' | 'print';
+  href?: string;
+}
+
+interface PaletteMeta {
+  name: string;
+  title: string;
+  location: string;
+  email: string;
+}
+
+declare global {
+  interface Window {
+    __cmdk?: {
+      open: () => void;
+      close: () => void;
+      toggle: () => void;
+    };
+  }
+}
+
+const THEME_KEY = 'theme-preference';
+const COMMANDS = ['help', 'ls', 'cat', 'grep', 'whoami', 'open', 'theme', 'email', 'clear', 'ask'];
+
+// Minimal inline-SVG sprite (lucide-flavored) so the palette has zero icon-font
+// dependency and works regardless of astro-icon hydration timing.
+const ICONS: Record<string, string> = {
+  home: '<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 22V12h6v10"/>',
+  user: '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
+  folder: '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>',
+  layers: '<path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m22 17.65-9.17 4.16a2 2 0 0 1-1.66 0L2 17.65"/><path d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"/>',
+  file: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/>',
+  mail: '<rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>',
+  box: '<path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>',
+  sparkles: '<path d="M9.94 14.66a1 1 0 0 1-.66.66l-2.2.73a.5.5 0 0 0 0 .94l2.2.73a1 1 0 0 1 .66.66l.73 2.2a.5.5 0 0 0 .94 0l.73-2.2a1 1 0 0 1 .66-.66l2.2-.73a.5.5 0 0 0 0-.94l-2.2-.73a1 1 0 0 1-.66-.66l-.73-2.2a.5.5 0 0 0-.94 0z"/><path d="M5 3v4"/><path d="M3 5h4"/>',
+  code: '<path d="m16 18 6-6-6-6"/><path d="m8 6-6 6 6 6"/>',
+  heart: '<path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.51 4.04 3 5.5l7 7Z"/>',
+  briefcase: '<rect width="20" height="14" x="2" y="7" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>',
+  copy: '<rect width="14" height="14" x="8" y="8" rx="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
+  github: '<path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/>',
+  linkedin: '<path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/>',
+  contrast: '<circle cx="12" cy="12" r="10"/><path d="M12 18a6 6 0 0 0 0-12v12z"/>',
+  printer: '<path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><path d="M6 9V2h12v7"/><rect width="12" height="8" x="6" y="14"/>',
+  terminal: '<path d="m4 17 6-6-6-6"/><path d="M12 19h8"/>',
+};
+
+function svg(icon: string): string {
+  const path = ICONS[icon] ?? ICONS.box;
+  return `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${path}</svg>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}
+
+// ---------- Fuzzy matcher (subsequence scoring) ----------
+
+interface Match {
+  score: number;
+  indices: number[];
+}
+
+function fuzzy(query: string, target: string): Match | null {
+  if (!query) return { score: 0, indices: [] };
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let qi = 0;
+  let score = 0;
+  let prevIdx = -2;
+  const indices: number[] = [];
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      indices.push(ti);
+      // Contiguous + word-boundary bonuses; earlier matches score higher.
+      if (ti === prevIdx + 1) score += 6;
+      if (ti === 0 || /[\s\-_/.]/.test(t[ti - 1])) score += 8;
+      score += Math.max(0, 4 - ti * 0.05);
+      prevIdx = ti;
+      qi++;
+    }
+  }
+  if (qi < q.length) return null;
+  return { score, indices };
+}
+
+function highlight(text: string, indices: number[]): string {
+  if (!indices.length) return escapeHtml(text);
+  const set = new Set(indices);
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = escapeHtml(text[i]);
+    out += set.has(i) ? `<mark>${ch}</mark>` : ch;
+  }
+  return out;
+}
+
+// ---------- Runtime ----------
+
+function init() {
+  const root = document.getElementById('cmdk-root');
+  const dataEl = document.getElementById('cmdk-data');
+  const input = document.getElementById('cmdk-input') as HTMLInputElement | null;
+  const list = document.getElementById('cmdk-list');
+  if (!root || !dataEl || !input || !list) return;
+
+  let entries: PaletteEntry[] = [];
+  let meta: PaletteMeta;
+  try {
+    const parsed = JSON.parse(dataEl.textContent || '{}');
+    entries = parsed.entries ?? [];
+    meta = parsed.meta;
+  } catch {
+    return;
+  }
+
+  const overlay = root.querySelector('[data-cmdk-overlay]');
+  const promptEl = root.querySelector('[data-cmdk-prompt]');
+  const modeEl = root.querySelector('[data-cmdk-mode]') as HTMLElement | null;
+
+  let active = 0; // active spotlight item index
+  let visible: PaletteEntry[] = [];
+  let scrollback: string[] = []; // committed terminal lines (HTML)
+  let lastFocused: Element | null = null;
+
+  const isTerminal = (q: string) => COMMANDS.includes(q.trim().split(/\s+/)[0]?.toLowerCase());
+
+  // ----- open / close -----
+  function open() {
+    if (!root!.hidden) return;
+    lastFocused = document.activeElement;
+    root!.hidden = false;
+    document.body.classList.add('cmdk-open');
+    requestAnimationFrame(() => root!.classList.add('is-open'));
+    input!.value = '';
+    render();
+    input!.focus();
+  }
+
+  function close() {
+    if (root!.hidden) return;
+    root!.classList.remove('is-open');
+    document.body.classList.remove('cmdk-open');
+    const done = () => {
+      root!.hidden = true;
+      root!.removeEventListener('transitionend', onEnd);
+    };
+    const onEnd = (e: TransitionEvent) => {
+      if (e.target === root || (e.target as HTMLElement).classList?.contains('cmdk-dialog')) done();
+    };
+    root!.addEventListener('transitionend', onEnd);
+    setTimeout(done, 260); // fallback if transitionend doesn't fire
+    if (lastFocused instanceof HTMLElement) lastFocused.focus();
+  }
+
+  function toggle() {
+    root!.hidden ? open() : close();
+  }
+
+  // ----- spotlight render -----
+  function renderSpotlight(q: string) {
+    root!.classList.remove('is-terminal');
+    promptEl!.innerHTML =
+      '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>';
+    if (modeEl) modeEl.hidden = true;
+
+    const scored = entries
+      .map((e) => {
+        const hay = [e.title, e.subtitle ?? '', (e.keywords ?? []).join(' ')].join(' ');
+        const m = q ? fuzzy(q, hay) : { score: 0, indices: [] };
+        if (!m) return null;
+        // Re-run on the title alone so highlight indices land on the title text.
+        const titleMatch = q ? fuzzy(q, e.title) : { score: 0, indices: [] };
+        return { e, score: m.score, titleIndices: titleMatch ? titleMatch.indices : [] };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
+
+    if (!q) {
+      // Preserve declared order when no query.
+      visible = entries.slice();
+    } else {
+      scored.sort((a, b) => b.score - a.score);
+      visible = scored.map((s) => s.e);
+    }
+
+    if (!visible.length) {
+      list!.innerHTML = `<div class="cmdk-empty">No matches for “${escapeHtml(q)}”. Try <code>help</code> or <code>grep ${escapeHtml(q)}</code>.</div>`;
+      return;
+    }
+
+    const indexById = new Map(scored.map((s) => [s.e.id, s.titleIndices]));
+    let html = '';
+    let lastGroup = '';
+    visible.forEach((e, i) => {
+      if (e.group !== lastGroup) {
+        html += `<div class="cmdk-group-label">${escapeHtml(e.group)}</div>`;
+        lastGroup = e.group;
+      }
+      const titleHtml = q ? highlight(e.title, indexById.get(e.id) ?? []) : escapeHtml(e.title);
+      const sub = e.subtitle ? `<div class="cmdk-item-sub">${escapeHtml(e.subtitle)}</div>` : '';
+      html += `
+        <div class="cmdk-item" role="option" data-idx="${i}" aria-selected="${i === active}">
+          <span class="cmdk-item-icon">${svg(e.icon)}</span>
+          <span class="cmdk-item-text">
+            <div class="cmdk-item-title">${titleHtml}</div>${sub}
+          </span>
+          <span class="cmdk-item-go">↵</span>
+        </div>`;
+    });
+    list!.innerHTML = html;
+  }
+
+  // ----- terminal render -----
+  function renderTerminal(q: string) {
+    root!.classList.add('is-terminal');
+    promptEl!.textContent = '$';
+    if (modeEl) modeEl.hidden = false;
+
+    const liveHtml = runCommand(q, /* preview */ true);
+    const lines = [...scrollback];
+    if (q.trim()) {
+      lines.push(`<div class="cmdk-term-line cmdk-term-cmd">${escapeHtml(q)}</div>${liveHtml}`);
+      lines.push('<div class="cmdk-term-run">press <kbd>↵</kbd> to run</div>');
+    }
+    list!.innerHTML = `<div class="cmdk-term">${lines.join('')}</div>`;
+    list!.scrollTop = list!.scrollHeight;
+  }
+
+  function render() {
+    const q = input!.value;
+    active = 0;
+    if (isTerminal(q)) renderTerminal(q);
+    else renderSpotlight(q);
+  }
+
+  // ----- command interpreter -----
+  function corpus() {
+    return entries.filter((e) => e.body || e.subtitle);
+  }
+
+  function runCommand(raw: string, preview: boolean): string {
+    const parts = raw.trim().split(/\s+/);
+    const cmd = (parts[0] || '').toLowerCase();
+    const arg = parts.slice(1).join(' ').trim();
+    const line = (cls: string, html: string) => `<div class="cmdk-term-line ${cls}">${html}</div>`;
+    const muted = (s: string) => line('cmdk-term-muted', escapeHtml(s));
+
+    switch (cmd) {
+      case 'help':
+        return [
+          muted('Available commands:'),
+          line('', '<span class="cmdk-term-key">ls</span>            list sections & pages'),
+          line('', '<span class="cmdk-term-key">cat</span> &lt;topic&gt;   print a section (e.g. cat about)'),
+          line('', '<span class="cmdk-term-key">grep</span> &lt;term&gt;   search the whole site'),
+          line('', '<span class="cmdk-term-key">whoami</span>        who is this'),
+          line('', '<span class="cmdk-term-key">open</span> &lt;target&gt;  navigate (e.g. open work)'),
+          line('', '<span class="cmdk-term-key">theme</span> [mode]   toggle / set light|dark'),
+          line('', '<span class="cmdk-term-key">email</span>         copy email address'),
+          line('', '<span class="cmdk-term-key">ask</span> &lt;question&gt; ask the site (AI — preview)'),
+          line('', '<span class="cmdk-term-key">clear</span>         clear the screen'),
+          muted('Or just start typing to search.'),
+        ].join('');
+
+      case 'whoami':
+        return [
+          line('', `<span class="cmdk-term-key">${escapeHtml(meta.name)}</span> — ${escapeHtml(meta.title)}`),
+          muted(`📍 ${meta.location}   ✉  ${meta.email}`),
+        ].join('');
+
+      case 'ls': {
+        const groups = [...new Set(entries.map((e) => e.group))];
+        const want = arg.toLowerCase();
+        const rows = entries
+          .filter((e) => !want || e.group.toLowerCase() === want)
+          .map((e) => {
+            const path = e.href ?? `(action: ${e.action})`;
+            return line('', `<span class="cmdk-term-key">${escapeHtml(e.title)}</span>  <span class="cmdk-term-path">${escapeHtml(path)}</span>`);
+          });
+        if (!rows.length) return muted(`ls: no such group: ${arg}. Try one of: ${groups.join(', ')}`);
+        return rows.join('');
+      }
+
+      case 'cat': {
+        if (!arg) return muted('usage: cat <topic>   e.g. cat about | cat skills | cat interests');
+        const e = findEntry(arg);
+        if (!e) return muted(`cat: ${arg}: no such topic. Try: ls`);
+        const body = e.body || e.subtitle || '(no content)';
+        return body
+          .split('\n')
+          .map((l) => line('', escapeHtml(l)))
+          .join('') + (e.href ? muted(`→ ${e.href}`) : '');
+      }
+
+      case 'grep': {
+        if (!arg) return muted('usage: grep <term>');
+        const re = new RegExp(arg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+        const hits: string[] = [];
+        corpus().forEach((e) => {
+          const text = `${e.title}. ${e.subtitle ?? ''} ${e.body ?? ''}`;
+          text.split(/(?<=[.!?\n])\s+/).forEach((sentence) => {
+            if (re.test(sentence)) {
+              const hl = escapeHtml(sentence.trim()).replace(new RegExp(`(${escapeHtml(arg)})`, 'ig'), '<mark>$1</mark>');
+              hits.push(line('', `<span class="cmdk-term-path">${escapeHtml(e.href ?? e.id)}:</span> ${hl}`));
+            }
+          });
+        });
+        return hits.length ? hits.slice(0, 12).join('') : muted(`grep: no matches for “${arg}”`);
+      }
+
+      case 'open': {
+        const e = findEntry(arg);
+        if (!e) return muted(`open: ${arg}: not found. Try: ls`);
+        if (!preview) runAction(e);
+        return line('', `opening <span class="cmdk-term-key">${escapeHtml(e.title)}</span> ${e.href ? `<span class="cmdk-term-path">${escapeHtml(e.href)}</span>` : ''}…`);
+      }
+
+      case 'theme': {
+        const mode = arg.toLowerCase();
+        if (!preview) applyTheme(mode === 'dark' || mode === 'light' ? mode : 'toggle');
+        const now = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+        return line('', `theme → <span class="cmdk-term-key">${preview ? (mode || 'toggle') : now}</span>`);
+      }
+
+      case 'email':
+        if (!preview) copyEmail();
+        return line('', `<span class="cmdk-term-key">${escapeHtml(meta.email)}</span> ${preview ? '<span class="cmdk-term-muted">(↵ to copy)</span>' : '<span class="cmdk-term-muted">copied ✓</span>'}`);
+
+      case 'ask': {
+        if (!arg) return muted('usage: ask <question>   e.g. ask what did you build with TensorRT?');
+        // Honest stub: real answers would route to an MCP/LLM endpoint. For
+        // now we fall back to a local grep so the command still does something.
+        const local = runCommand(`grep ${arg.split(/\s+/).slice(0, 3).join(' ')}`, true);
+        return [
+          muted('🤖 AI search is a preview — not wired to a model yet.'),
+          muted('It would route to an edge function / MCP. Closest local hits:'),
+          local,
+        ].join('');
+      }
+
+      case 'clear':
+        if (!preview) {
+          scrollback = [];
+          requestAnimationFrame(() => (list!.innerHTML = '<div class="cmdk-term"></div>'));
+        }
+        return '';
+
+      default:
+        return muted(`${cmd}: command not found. Type 'help'.`);
+    }
+  }
+
+  function findEntry(term: string): PaletteEntry | undefined {
+    const t = term.toLowerCase();
+    return (
+      entries.find((e) => e.id === t || e.id === `ans-${t}` || e.title.toLowerCase() === t) ||
+      entries.find((e) => e.title.toLowerCase().includes(t) || (e.keywords ?? []).some((k) => k.toLowerCase() === t)) ||
+      entries.find((e) => (e.keywords ?? []).some((k) => k.toLowerCase().includes(t)))
+    );
+  }
+
+  // ----- actions -----
+  function applyTheme(mode: 'dark' | 'light' | 'toggle') {
+    const html = document.documentElement;
+    const dark = mode === 'toggle' ? !html.classList.contains('dark') : mode === 'dark';
+    html.classList.toggle('dark', dark);
+    try {
+      localStorage.setItem(THEME_KEY, dark ? 'dark' : 'light');
+    } catch {}
+  }
+
+  function copyEmail() {
+    navigator.clipboard?.writeText(meta.email).catch(() => {});
+  }
+
+  function runAction(e: PaletteEntry) {
+    switch (e.action) {
+      case 'navigate':
+        close();
+        if (e.href) window.location.assign(e.href);
+        break;
+      case 'open-url':
+        if (e.href) window.open(e.href, e.href.startsWith('mailto:') ? '_self' : '_blank', 'noopener');
+        close();
+        break;
+      case 'copy-email':
+        copyEmail();
+        close();
+        break;
+      case 'toggle-theme':
+        applyTheme('toggle');
+        break;
+      case 'print':
+        close();
+        break;
+    }
+  }
+
+  // ----- events -----
+  input.addEventListener('input', render);
+
+  input.addEventListener('keydown', (e) => {
+    const terminal = isTerminal(input.value);
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (terminal) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const q = input.value;
+        if (q.trim()) {
+          const out = runCommand(q, /* preview */ false);
+          const lower = q.trim().split(/\s+/)[0].toLowerCase();
+          if (lower !== 'clear') {
+            scrollback.push(`<div class="cmdk-term-line cmdk-term-cmd">${escapeHtml(q)}</div>${out}`);
+          }
+          input.value = '';
+          render();
+        }
+      }
+      return;
+    }
+    // Spotlight navigation
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      active = Math.min(active + 1, visible.length - 1);
+      syncActive();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      active = Math.max(active - 1, 0);
+      syncActive();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const e2 = visible[active];
+      if (e2) runAction(e2);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      active = 0;
+      syncActive();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      active = visible.length - 1;
+      syncActive();
+    }
+  });
+
+  function syncActive() {
+    const items = list!.querySelectorAll<HTMLElement>('.cmdk-item');
+    items.forEach((el) => {
+      const idx = Number(el.dataset.idx);
+      const sel = idx === active;
+      el.setAttribute('aria-selected', String(sel));
+      if (sel) el.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  list.addEventListener('mousemove', (e) => {
+    const item = (e.target as HTMLElement).closest<HTMLElement>('.cmdk-item');
+    if (item) {
+      const idx = Number(item.dataset.idx);
+      if (idx !== active) {
+        active = idx;
+        syncActive();
+      }
+    }
+  });
+
+  list.addEventListener('click', (e) => {
+    const item = (e.target as HTMLElement).closest<HTMLElement>('.cmdk-item');
+    if (item) {
+      const idx = Number(item.dataset.idx);
+      const entry = visible[idx];
+      if (entry) runAction(entry);
+    }
+  });
+
+  overlay?.addEventListener('click', close);
+
+  // Global hotkeys: ⌘K / Ctrl+K toggles; "/" opens when not already typing.
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      toggle();
+      return;
+    }
+    if (e.key === '/' && root!.hidden) {
+      const t = e.target as HTMLElement;
+      const typing = t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+      if (!typing) {
+        e.preventDefault();
+        open();
+      }
+    }
+  });
+
+  // Any element with [data-cmdk-open] (e.g. the nav button) opens the palette.
+  document.addEventListener('click', (e) => {
+    const trigger = (e.target as HTMLElement).closest('[data-cmdk-open]');
+    if (trigger) {
+      e.preventDefault();
+      open();
+    }
+  });
+
+  window.__cmdk = { open, close, toggle };
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+
+export {};

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -18,7 +18,7 @@ interface PaletteEntry {
   subtitle?: string;
   keywords?: string[];
   body?: string;
-  action: 'navigate' | 'open-url' | 'copy-email' | 'toggle-theme' | 'print';
+  action: 'navigate' | 'open-url' | 'copy-email' | 'toggle-theme';
   href?: string;
 }
 
@@ -42,8 +42,11 @@ declare global {
 const THEME_KEY = 'theme-preference';
 const COMMANDS = ['help', 'ls', 'cat', 'grep', 'whoami', 'open', 'theme', 'email', 'clear', 'ask'];
 
-// Minimal inline-SVG sprite (lucide-flavored) so the palette has zero icon-font
-// dependency and works regardless of astro-icon hydration timing.
+// Minimal inline-SVG sprite (lucide path data). The client module injects
+// per-result icons via innerHTML at runtime and can't call Astro's <Icon>
+// component (which only renders at build time), so the glyphs are inlined
+// here. Trade-off: these paths can drift from the lucide version astro-icon
+// resolves elsewhere — keep them in sync if icons look off.
 const ICONS: Record<string, string> = {
   home: '<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 22V12h6v10"/>',
   user: '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
@@ -141,18 +144,40 @@ function init() {
   let visible: PaletteEntry[] = [];
   let scrollback: string[] = []; // committed terminal lines (HTML)
   let lastFocused: Element | null = null;
+  let closeTimer: number | null = null; // pending hide after the close transition
 
   const isTerminal = (q: string) => COMMANDS.includes(q.trim().split(/\s+/)[0]?.toLowerCase());
 
   // ----- open / close -----
+  // The close animation hides the root only after the transition (or a 260ms
+  // fallback) so it can fade out. If the user re-opens within that window we
+  // must cancel the pending hide, or the stale timer would blank the freshly
+  // opened palette.
+  function finishClose() {
+    closeTimer = null;
+    root!.removeEventListener('transitionend', onCloseTransitionEnd);
+    if (root!.classList.contains('is-open')) return; // re-opened mid-transition
+    root!.hidden = true;
+  }
+  function onCloseTransitionEnd(e: TransitionEvent) {
+    if (e.target === root || (e.target as HTMLElement).classList?.contains('cmdk-dialog')) finishClose();
+  }
+
   function open() {
-    if (!root!.hidden) return;
-    lastFocused = document.activeElement;
+    if (closeTimer !== null) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+    root!.removeEventListener('transitionend', onCloseTransitionEnd);
+    const wasHidden = root!.hidden;
     root!.hidden = false;
     document.body.classList.add('cmdk-open');
     requestAnimationFrame(() => root!.classList.add('is-open'));
-    input!.value = '';
-    render();
+    if (wasHidden) {
+      lastFocused = document.activeElement;
+      input!.value = '';
+      render();
+    }
     input!.focus();
   }
 
@@ -160,15 +185,9 @@ function init() {
     if (root!.hidden) return;
     root!.classList.remove('is-open');
     document.body.classList.remove('cmdk-open');
-    const done = () => {
-      root!.hidden = true;
-      root!.removeEventListener('transitionend', onEnd);
-    };
-    const onEnd = (e: TransitionEvent) => {
-      if (e.target === root || (e.target as HTMLElement).classList?.contains('cmdk-dialog')) done();
-    };
-    root!.addEventListener('transitionend', onEnd);
-    setTimeout(done, 260); // fallback if transitionend doesn't fire
+    root!.addEventListener('transitionend', onCloseTransitionEnd);
+    if (closeTimer !== null) clearTimeout(closeTimer);
+    closeTimer = window.setTimeout(finishClose, 260); // fallback if transitionend doesn't fire
     if (lastFocused instanceof HTMLElement) lastFocused.focus();
   }
 
@@ -312,13 +331,16 @@ function init() {
 
       case 'grep': {
         if (!arg) return muted('usage: grep <term>');
-        const re = new RegExp(arg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+        // Escape regex metacharacters once: a query like `grep c++` would
+        // otherwise build an invalid pattern and throw on every keystroke.
+        const safe = arg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const re = new RegExp(safe, 'i');
         const hits: string[] = [];
         corpus().forEach((e) => {
           const text = `${e.title}. ${e.subtitle ?? ''} ${e.body ?? ''}`;
           text.split(/(?<=[.!?\n])\s+/).forEach((sentence) => {
             if (re.test(sentence)) {
-              const hl = escapeHtml(sentence.trim()).replace(new RegExp(`(${escapeHtml(arg)})`, 'ig'), '<mark>$1</mark>');
+              const hl = escapeHtml(sentence.trim()).replace(new RegExp(`(${safe})`, 'ig'), '<mark>$1</mark>');
               hits.push(line('', `<span class="cmdk-term-path">${escapeHtml(e.href ?? e.id)}:</span> ${hl}`));
             }
           });
@@ -336,7 +358,8 @@ function init() {
       case 'theme': {
         const mode = arg.toLowerCase();
         if (!preview) applyTheme(mode === 'dark' || mode === 'light' ? mode : 'toggle');
-        const now = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+        // After applyTheme, html.dark reflects the *new* state — report it as-is.
+        const now = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
         return line('', `theme → <span class="cmdk-term-key">${preview ? (mode || 'toggle') : now}</span>`);
       }
 
@@ -357,10 +380,10 @@ function init() {
       }
 
       case 'clear':
-        if (!preview) {
-          scrollback = [];
-          requestAnimationFrame(() => (list!.innerHTML = '<div class="cmdk-term"></div>'));
-        }
+        // Just drop the scrollback. The Enter handler clears the input and
+        // calls render() next, which repaints from the (now empty) state — a
+        // queued rAF wipe here would race that render and blank the palette.
+        if (!preview) scrollback = [];
         return '';
 
       default:
@@ -408,9 +431,6 @@ function init() {
       case 'toggle-theme':
         applyTheme('toggle');
         break;
-      case 'print':
-        close();
-        break;
     }
   }
 
@@ -422,6 +442,13 @@ function init() {
     if (e.key === 'Escape') {
       e.preventDefault();
       close();
+      return;
+    }
+    // Focus trap: the input is the only focusable control in the dialog, so
+    // Tab/Shift+Tab would otherwise escape to the nav/page behind the overlay.
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      input.focus();
       return;
     }
     if (terminal) {
@@ -495,6 +522,14 @@ function init() {
   });
 
   overlay?.addEventListener('click', close);
+
+  // Belt-and-suspenders focus trap: if focus escapes the open dialog (e.g. a
+  // programmatic move), pull it back to the input.
+  document.addEventListener('focusin', (e) => {
+    if (root!.hidden) return;
+    const dialog = root!.querySelector('.cmdk-dialog');
+    if (dialog && !dialog.contains(e.target as Node)) input.focus();
+  });
 
   // Global hotkeys: ⌘K / Ctrl+K toggles; "/" opens when not already typing.
   document.addEventListener('keydown', (e) => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -212,6 +212,11 @@ html.dark .bento:hover {
   position: fixed;
   inset: 0 0 auto 0;
   z-index: 40;
+  /* Suppress double-tap-to-zoom (and the legacy ~300ms tap delay) across the
+     whole nav bar and its mobile dropdown. `manipulation` keeps normal scroll
+     and pinch-zoom; an ancestor opting out is enough to disable double-tap zoom
+     for taps on any descendant link/button. */
+  touch-action: manipulation;
 }
 
 /* When a bento case-study modal is open, the backdrop (z:200) visually


### PR DESCRIPTION
## What

A prototype command palette for the portfolio — the **cmdk UX without the React runtime**. Triggered from a new nav search button and a global `⌘K` / `Ctrl+K` (and `/`) hotkey.

It's a **spotlight + terminal hybrid**, so it covers both ideas from the brief:

### Spotlight mode (default)
Fuzzy-filter a registry of:
- **Navigate** — Home, About, Work, Stack, Résumé, Contact + each project detail page
- **Answers** — "Who is Tanel?", Skills & tools, Programming languages, Hobbies & interests, Experience
- **Actions** — Copy email, Send email, Open GitHub/LinkedIn, Toggle theme, Print résumé

Arrow-key navigable, ARIA `listbox`, match-highlighting, mouse + keyboard.

### Terminal mode
When the query starts with a known command, the body becomes a shell transcript over the **same content index**:

```
help            list commands
ls [group]      list sections & pages with their paths
cat <topic>     print a section (cat about / cat skills / cat interests)
grep <term>     search the whole site, sentence-level, with path:match output
whoami          name · role · location · email
open <target>   navigate (open work)
theme [mode]    toggle / set light|dark
email           copy email
ask <question>  AI search — see note below
clear           clear the screen
```

So `grep tensorrt`, `cat about`, `ls projects`, `whoami` all work as the brief described ("literal unix commands for searching/grepping the website").

## Why no React
The site is Astro + vanilla-TS islands (e.g. `liquid-glass.ts`) with **zero UI framework**. Both `dip/cmdk` and `pacocoursey/cmdk` require **React 18+** — pulling them in means shipping React + ReactDOM + a hydration island (~50 KB gzip) for one widget, against the project's performance-minded, framework-free ethos. This prototype reproduces the cmdk *interaction model* in a dependency-free module that mirrors the existing `liquid-glass.ts` pattern: server-rendered markup + a serialized JSON index, behaviour auto-wired on `DOMContentLoaded`, imperative handle on `window.__cmdk`.

## On the "agent / Supabase-style search" idea
`ask <question>` is an **honest stub**: it notes that real answers would route to an edge function / MCP endpoint, then falls back to a local `grep` so the command still does something. A static GitHub Pages site can't host an LLM call directly — wiring that up (a small serverless/edge function or MCP bridge) is the natural follow-up if we like the direction.

## Files
- `src/components/CommandPalette.astro` — markup, scoped styles, server-built content index (from `resume.ts` + projects collection)
- `src/scripts/command-palette.ts` — engine (fuzzy matcher, spotlight + terminal renderers, command interpreter, hotkeys)
- `src/components/Nav.astro` — nav search trigger (`data-cmdk-open`) + styles
- `src/layouts/BaseLayout.astro` — mount component + import script

## Verification
`npm run check` → 0 errors. `npm run build` → 6 pages built; palette markup, 20 serialized entries, and the bundled module all present in `dist/`. **Build-only — not yet exercised in a live browser**, so a manual click-through (open, fuzzy search, arrow nav, `grep`/`cat`/`theme`) is the recommended next check.

## Open questions for you
1. **Placement** — nav button + global hotkey for now. Keep both, or move the trigger elsewhere (e.g. hero)?
2. **Terminal scope** — happy with this command set, or want more/fewer?
3. **AI search** — worth wiring `ask` to a real edge function / MCP, or leave as a local grep?

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01UruvPm2z3upRALyQEF4Ckc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UruvPm2z3upRALyQEF4Ckc)_