### PR TITLE
Fix: lock background scroll behind ⌘K palette from JS (not just :has() CSS)

### DIFF
--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -226,13 +226,6 @@ const meta = {
   }
   .cmdk-root[hidden] { display: none; }
 
-  /* Scroll lock. Scrollbars are hidden globally so there's no layout shift,
-     but global.css sets html{overflow-x:clip} which makes <html> the real
-     scroller — so body{overflow:hidden} alone won't stop the background from
-     scrolling. Lock html too, matching the bento modal precedent. */
-  body.cmdk-open { overflow: hidden; }
-  html:has(body.cmdk-open) { overflow-y: hidden; }
-
   .cmdk-overlay {
     position: fixed;
     inset: 0;
@@ -327,12 +320,6 @@ const meta = {
     padding: 8px;
     flex: 1;
     min-height: 0;
-    /* The dialog's scrollable region. overscroll-behavior:contain stops a flick
-       that reaches the list's top/bottom edge from chain-scrolling the page
-       behind it; touch-action:pan-y keeps the list itself vertically
-       scrollable. Complements the JS scroll lock in command-palette.ts. */
-    overscroll-behavior: contain;
-    touch-action: pan-y;
   }
 
   /* ----- Spotlight list ----- */

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -327,6 +327,12 @@ const meta = {
     padding: 8px;
     flex: 1;
     min-height: 0;
+    /* The dialog's scrollable region. overscroll-behavior:contain stops a flick
+       that reaches the list's top/bottom edge from chain-scrolling the page
+       behind it; touch-action:pan-y keeps the list itself vertically
+       scrollable. Complements the JS scroll lock in command-palette.ts. */
+    overscroll-behavior: contain;
+    touch-action: pan-y;
   }
 
   /* ----- Spotlight list ----- */

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -146,27 +146,8 @@ function init() {
   let scrollback: string[] = []; // committed terminal lines (HTML)
   let lastFocused: Element | null = null;
   let closeTimer: number | null = null; // pending hide after the close transition
-  let prevHtmlOverflow = ''; // saved html overflow for the JS scroll lock
 
   const isTerminal = (q: string) => COMMANDS.includes(q.trim().split(/\s+/)[0]?.toLowerCase());
-
-  // Scroll lock driven from JS, not just CSS. The CSS rule relies on
-  // `html:has(body.cmdk-open)`, but <html> is the real scroller here and :has()
-  // isn't supported everywhere (older Safari/Firefox, some in-app webviews) —
-  // where it's missing the background scrolls freely behind the palette. Lock
-  // <html> directly so it works regardless of :has() support and for wheel and
-  // trackpad scroll (the touchmove guard below only covers touch). Not
-  // position:fixed — see CLAUDE.md, that broke scroll position twice on iOS.
-  // Scrollbars are hidden globally (scrollbar-width:none), so there's no shift.
-  function lockScroll() {
-    const html = document.documentElement;
-    prevHtmlOverflow = html.style.overflow;
-    html.style.overflow = 'hidden';
-  }
-  function unlockScroll() {
-    document.documentElement.style.overflow = prevHtmlOverflow;
-  }
-
 
   // ----- open / close -----
   // The close animation hides the root only after the transition (or a 260ms
@@ -191,10 +172,8 @@ function init() {
     root!.removeEventListener('transitionend', onCloseTransitionEnd);
     const wasHidden = root!.hidden;
     root!.hidden = false;
-    document.body.classList.add('cmdk-open');
     requestAnimationFrame(() => root!.classList.add('is-open'));
     if (wasHidden) {
-      lockScroll();
       lastFocused = document.activeElement;
       input!.value = '';
       render();
@@ -205,8 +184,6 @@ function init() {
   function close() {
     if (root!.hidden) return;
     root!.classList.remove('is-open');
-    document.body.classList.remove('cmdk-open');
-    unlockScroll();
     root!.addEventListener('transitionend', onCloseTransitionEnd);
     if (closeTimer !== null) clearTimeout(closeTimer);
     closeTimer = window.setTimeout(finishClose, 260); // fallback if transitionend doesn't fire
@@ -537,23 +514,6 @@ function init() {
   });
 
   overlay?.addEventListener('click', close);
-
-  // iOS touch-scroll guard. The CSS lock (body.cmdk-open{overflow:hidden} +
-  // html:has(...)) stops wheel/keyboard scroll, but iOS Safari lets touch and
-  // momentum scrolling bleed through overflow:hidden on the background. Block
-  // touchmove while the palette is open, except inside the scrollable results
-  // list so it can still be flicked. Non-passive so preventDefault() works.
-  // (Deliberately not position:fixed — see CLAUDE.md, that broke scroll
-  // position twice on iOS.)
-  document.addEventListener(
-    'touchmove',
-    (e) => {
-      if (root!.hidden) return;
-      if (list && list.contains(e.target as Node)) return; // allow list scroll
-      e.preventDefault();
-    },
-    { passive: false },
-  );
 
   // Belt-and-suspenders focus trap: if focus escapes the open dialog (e.g. a
   // programmatic move), pull it back to the input.

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -146,8 +146,27 @@ function init() {
   let scrollback: string[] = []; // committed terminal lines (HTML)
   let lastFocused: Element | null = null;
   let closeTimer: number | null = null; // pending hide after the close transition
+  let prevHtmlOverflow = ''; // saved html overflow for the JS scroll lock
 
   const isTerminal = (q: string) => COMMANDS.includes(q.trim().split(/\s+/)[0]?.toLowerCase());
+
+  // Scroll lock driven from JS, not just CSS. The CSS rule relies on
+  // `html:has(body.cmdk-open)`, but <html> is the real scroller here and :has()
+  // isn't supported everywhere (older Safari/Firefox, some in-app webviews) —
+  // where it's missing the background scrolls freely behind the palette. Lock
+  // <html> directly so it works regardless of :has() support and for wheel and
+  // trackpad scroll (the touchmove guard below only covers touch). Not
+  // position:fixed — see CLAUDE.md, that broke scroll position twice on iOS.
+  // Scrollbars are hidden globally (scrollbar-width:none), so there's no shift.
+  function lockScroll() {
+    const html = document.documentElement;
+    prevHtmlOverflow = html.style.overflow;
+    html.style.overflow = 'hidden';
+  }
+  function unlockScroll() {
+    document.documentElement.style.overflow = prevHtmlOverflow;
+  }
+
 
   // ----- open / close -----
   // The close animation hides the root only after the transition (or a 260ms
@@ -175,6 +194,7 @@ function init() {
     document.body.classList.add('cmdk-open');
     requestAnimationFrame(() => root!.classList.add('is-open'));
     if (wasHidden) {
+      lockScroll();
       lastFocused = document.activeElement;
       input!.value = '';
       render();
@@ -186,6 +206,7 @@ function init() {
     if (root!.hidden) return;
     root!.classList.remove('is-open');
     document.body.classList.remove('cmdk-open');
+    unlockScroll();
     root!.addEventListener('transitionend', onCloseTransitionEnd);
     if (closeTimer !== null) clearTimeout(closeTimer);
     closeTimer = window.setTimeout(finishClose, 260); // fallback if transitionend doesn't fire


### PR DESCRIPTION
Closing without merging. Per discussion we're keeping the existing scroll lock from #34 (CSS + touchmove guard) on `main` and leaving the palette as-is for now, rather than either adding the JS lock or reverting scroll-locking. No production change.

(The branch ended up reverting all scroll-locking, which is not what we want to ship — `main` keeps the #34 behavior.)