### PR TITLE
Disable mobile zoom for an app-like feel

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,7 +48,10 @@ const personSchema = {
 <html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
 
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -93,6 +96,23 @@ const personSchema = {
           var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
           var useDark = saved ? saved === 'dark' : prefersDark;
           if (useDark) document.documentElement.classList.add('dark');
+        } catch (_) {}
+      })();
+    </script>
+
+    <script is:inline>
+      // App-like mobile: suppress browser zoom gestures.
+      // The viewport meta (maximum-scale=1, user-scalable=no) covers Android
+      // Chrome/Firefox, but iOS Safari has ignored user-scalable since iOS 10,
+      // so pinch-zoom must be cancelled at the gesture* events here. Double-tap
+      // zoom is handled separately by `touch-action: manipulation` in
+      // global.css. No imports allowed in is:inline scripts.
+      (function () {
+        try {
+          var prevent = function (e) { e.preventDefault(); };
+          document.addEventListener('gesturestart', prevent, { passive: false });
+          document.addEventListener('gesturechange', prevent, { passive: false });
+          document.addEventListener('gestureend', prevent, { passive: false });
         } catch (_) {}
       })();
     </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,6 +61,10 @@ html.dark {
 html {
   background: var(--bg);
   color: var(--ink);
+  /* App-like mobile: keep text at its authored size (don't let iOS inflate
+     font sizes on orientation change) so the layout reads like a native app. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 /* Hide scrollbars globally while keeping scroll functionality.
@@ -89,6 +93,12 @@ body {
   position: relative;
   isolation: isolate;
   min-height: 100vh;
+  /* Suppress double-tap-to-zoom (and the legacy ~300ms tap delay) page-wide so
+     the site behaves like a native app. `manipulation` still permits normal
+     scrolling; pinch-zoom is blocked separately (viewport meta on Android,
+     gesture* listeners on iOS — see BaseLayout). The nav sets this on itself
+     too as a defensive belt; this body rule covers everything else. */
+  touch-action: manipulation;
 }
 
 ::selection { background: var(--ink); color: var(--bg); }


### PR DESCRIPTION
## What & why

Makes the site behave more like a native mobile app by disabling browser zoom gestures. Because no single switch covers every engine, this is three coordinated pieces:

| Engine | Pinch-zoom blocked by | Double-tap-zoom blocked by |
|--------|----------------------|----------------------------|
| Android Chrome / Firefox | viewport `user-scalable=no` | `touch-action: manipulation` |
| iOS Safari (≥ iOS 10) | `gesturestart`/`gesturechange`/`gestureend` `preventDefault` — it **ignores** `user-scalable` for accessibility | `touch-action: manipulation` |

## Changes

- **`src/layouts/BaseLayout.astro`**
  - viewport meta: add `maximum-scale=1.0, user-scalable=no`
  - new pre-paint `is:inline` script cancelling the iOS `gesture*` events (matches the existing inline-script convention; no imports)
- **`src/styles/global.css`**
  - `body { touch-action: manipulation }` — page-wide double-tap-zoom + 300ms-delay suppression (the nav already did this for itself; this generalizes it)
  - `html { text-size-adjust: 100% }` — stop iOS inflating font sizes on orientation change

## Accessibility note

Disabling user zoom removes a genuine accessibility affordance for low-vision users. This is an intentional trade-off for the app-like feel — text remains at its authored (readable) size and respects the OS Dynamic Type / browser default font size; only the manual pinch/double-tap zoom is removed.

## Verification

- `npm run check` → 0 errors / 0 warnings / 0 hints
- `npm run build` → 6 pages built, clean

No automated tests in this repo; the above is build-only verification. Worth a manual check on a real iOS device since the iOS gesture path can't be exercised in a desktop browser.

https://claude.ai/code/session_01DZJnyHmVwbiYsbm3w66wUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZJnyHmVwbiYsbm3w66wUa)_