### PR TITLE
Polish command palette for touch devices

### DIFF
--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -190,9 +190,9 @@ const meta = {
     <div id="cmdk-list" class="cmdk-body" role="listbox" aria-label="Results"></div>
 
     <div class="cmdk-footer">
-      <span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
-      <span><kbd>↵</kbd> select</span>
-      <span><kbd>esc</kbd> close</span>
+      <span class="cmdk-kbd-hint"><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+      <span class="cmdk-kbd-hint"><kbd>↵</kbd> select</span>
+      <span class="cmdk-kbd-hint"><kbd>esc</kbd> close</span>
       <span class="cmdk-footer-spacer"></span>
       <span class="cmdk-hint">Type <kbd>help</kbd> for commands</span>
     </div>
@@ -443,7 +443,10 @@ const meta = {
     color: var(--ink-dim);
   }
   @media (max-width: 520px) {
-    .cmdk-footer .cmdk-hint,
+    /* No physical keyboard on phones — the ↑↓/↵/esc hints are noise. Drop
+       them (and the now-redundant spacer) and keep only the still-relevant
+       "type help for commands" hint, left-aligned. */
+    .cmdk-footer .cmdk-kbd-hint,
     .cmdk-footer-spacer { display: none; }
   }
 </style>

--- a/src/scripts/command-palette.ts
+++ b/src/scripts/command-palette.ts
@@ -147,6 +147,16 @@ function init() {
   let lastFocused: Element | null = null;
   let closeTimer: number | null = null; // pending hide after the close transition
 
+  // Touch-primary devices (phones/tablets: no hover + coarse pointer) have no
+  // physical keyboard, so auto-focusing the input on open just pops the soft
+  // keyboard over a half-screen dialog before the user has decided whether to
+  // type or tap a result. On these devices we open as a tappable list and let
+  // the user focus the input themselves. Escape/close is document-level and
+  // tap-to-select doesn't need focus, so nothing breaks.
+  const isTouchPrimary =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+
   const isTerminal = (q: string) => COMMANDS.includes(q.trim().split(/\s+/)[0]?.toLowerCase());
 
   // ----- open / close -----
@@ -179,7 +189,9 @@ function init() {
       input!.value = '';
       render();
     }
-    input!.focus();
+    // Skip auto-focus on touch-primary devices to avoid popping the soft
+    // keyboard; the user taps the input when they actually want to type.
+    if (!isTouchPrimary) input!.focus();
   }
 
   function close() {


### PR DESCRIPTION
## What & why

Two small usability tweaks so the cmd-k command palette feels right on phones (it already has a touch entry point — the nav search icon — and iOS scroll-locking; these address the two remaining rough edges).

### 1. Don't auto-pop the soft keyboard on open
`open()` previously called `input.focus()` unconditionally, so on a phone the soft keyboard sprang up over the half-screen dialog before you'd decided whether to type or just tap a result.

Now the focus is gated behind a touch-primary check:
```ts
const isTouchPrimary =
  typeof window.matchMedia === 'function' &&
  window.matchMedia('(hover: none) and (pointer: coarse)').matches;
...
if (!isTouchPrimary) input!.focus();
```
On touch devices the palette opens as a tappable list; the user focuses the input themselves when they actually want to type. Nothing breaks: Escape is a document-level handler and tap-to-select doesn't need input focus.

### 2. Fix the footer hints below 520px
The footer shows `↑↓ navigate · ↵ select · esc close · … · type help for commands`. The old `@media (max-width:520px)` rule hid the **wrong** items — it dropped the useful "type help" hint and kept the keyboard-only ones that mean nothing on a touchscreen.

Now the three keyboard hints get a `.cmdk-kbd-hint` class and *they* are hidden on small screens, leaving the still-relevant help hint left-aligned.

## Verification

- `npm run check` → 0 errors / 0 warnings / 0 hints
- `npm run build` → 6 pages built, clean

Build-only (no test suite in this repo). The touch path can't be exercised in a desktop browser, so a quick check on a real phone is worthwhile — but the logic is a standard `(hover: none) and (pointer: coarse)` media query.

https://claude.ai/code/session_01DZJnyHmVwbiYsbm3w66wUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZJnyHmVwbiYsbm3w66wUa)_