### PR TITLE
Stop command-palette scroll-chaining to the page on iOS

### DIFF
--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -324,6 +324,11 @@ const meta = {
 
   .cmdk-body {
     overflow-y: auto;
+    /* Trap scroll inside the results list. Without this, flicking past the
+       list's top/bottom chains the scroll out to <html> and pans the page
+       behind the palette — most easily triggered on iOS once the soft
+       keyboard shrinks the visible dialog. Mirrors the bento grid's lock. */
+    overscroll-behavior: contain;
     padding: 8px;
     flex: 1;
     min-height: 0;


### PR DESCRIPTION
## Symptom

On iOS (reported on iPhone 14 Pro Max, iOS 26.5): open the command palette, tap the input so the soft keyboard appears, then drag — the page **behind** the palette scrolls, even though the background is supposed to be locked.

## Diagnosis

This is **not** the WebKit keyboard-pan path (that happens *during* the keyboard animation, programmatically, and would need the `position:fixed` body lock that `CLAUDE.md` warns burned us twice). The reporter confirmed it's **drag-driven, after the keyboard settles** — which is plain **scroll chaining**: a finger-flick scrolls the results list (`.cmdk-body`), hits its top/bottom bound, and the leftover scroll chains out to `<html>`, panning the page.

The existing lock (`body { overflow:hidden }` + `html:has(...)` + a `touchmove` guard) doesn't catch this because the `touchmove` guard *intentionally* allows scrolling inside the results list — and that list had no overscroll containment, unlike the bento grid (`BentoGrid.astro:352`) which already sets `overscroll-behavior: contain`. The soft keyboard just makes it trivial to trigger: it shrinks the visible dialog, so a short list over-flicks immediately.

## Fix

One line on `.cmdk-body`:
```css
overscroll-behavior: contain;
```
Traps the scroll inside the list so it can't chain to the page. Mirrors the bento grid's existing lock. Does **not** touch the `overflow:hidden` + `touchmove` mechanism, and deliberately avoids the `position:fixed` approach.

## Verification

- `npm run check` → 0 errors / 0 warnings / 0 hints
- `npm run build` → 6 pages built, clean

Build-only (no test suite). Per `CLAUDE.md`'s iOS-bug rule, the diagnosis was confirmed against the reporter's description (drag-driven, post-keyboard) before the fix — but a real-device recheck on the 14 Pro Max is the final confirmation since the touch path can't be reproduced in a desktop browser.

https://claude.ai/code/session_01DZJnyHmVwbiYsbm3w66wUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZJnyHmVwbiYsbm3w66wUa)_