### PR TITLE
Resume: open PDF inline (preview) with a clean tab title

### DIFF
--- a/scripts/resume-pdf/generate.ts
+++ b/scripts/resume-pdf/generate.ts
@@ -582,7 +582,7 @@ async function build(): Promise<{ bytes: Uint8Array; pageCount: number }> {
 
   // Metadata strings go through the same normalize + encode gate as on-page
   // text, so a stray non-WinAnsi char in the name can't silently bypass it.
-  const metaTitle = normalizeForPdf(`${resume.name} - Resume`);
+  const metaTitle = normalizeForPdf(`${resume.name} — ${resume.title}`);
   const metaAuthor = normalizeForPdf(resume.name);
   assertEncodable(metaTitle, fonts.regular, 'meta.title');
   assertEncodable(metaAuthor, fonts.regular, 'meta.author');

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -50,7 +50,6 @@ export interface ResumeData {
   interests?: string;
   meta: {
     updatedAt: string; // "2026-05" — month-level is enough for a CV
-    pdfFilename: string; // download filename (no extension) for the static /resume.pdf export
   };
 }
 
@@ -144,6 +143,5 @@ export const resume: ResumeData = {
     'Social dancing (tango argentino, Brazilian zouk), guitar and piano, physics.',
   meta: {
     updatedAt: '2026-06',
-    pdfFilename: 'Tanel_Treuberg_Software_Engineer',
   },
 };

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -20,16 +20,17 @@ import { resume } from '../data/resume';
       <ResumeModeToggle defaultMode="interactive" />
       <a
         href="/resume.pdf"
-        download={`${resume.meta.pdfFilename}.pdf`}
+        target="_blank"
+        rel="noopener"
         class="resume-print-btn"
-        aria-label="Download resume as PDF"
+        aria-label="Open resume PDF in a new tab"
       >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M12 3v12" />
-          <path d="m7 10 5 5 5-5" />
-          <path d="M5 21h14" />
+          <path d="M15 3h6v6" />
+          <path d="M10 14 21 3" />
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
         </svg>
-        <span>Export PDF</span>
+        <span>View PDF</span>
       </a>
     </header>
 


### PR DESCRIPTION
## Summary
- The resume **View PDF** button now opens `/resume.pdf` in a new tab (`target="_blank"`, inline preview) instead of force-downloading it. Users can still download from the browser's PDF viewer.
- PDF `/Title` metadata → **"Tanel Treuberg — Software Engineer"** so the preview tab/window title reads cleanly (was "… - Resume").
- Removed the now-unused `meta.pdfFilename` (it only fed the old `download` attribute).

## Notes
- Inline preview + `/Title` is what makes the nice tab title appear; a force-download would have shown the filename instead.
- Button relabeled "Export PDF" → "View PDF" with an open-in-new-tab icon to match the new behavior.

## Test plan
- [x] `npm run check`, `npm run build`
- [x] `npm run resume:pdf` + verify; `pdfinfo` Title = "Tanel Treuberg — Software Engineer"
- [x] Built markup: button is `target="_blank" rel="noopener"`, no `download`
- [ ] CI deploy ships it; clicking View PDF opens an inline preview with the clean tab title

🤖 Generated with [Claude Code](https://claude.com/claude-code)