### PR TITLE
Resume PDF: set DisplayDocTitle so the tab uses /Title

### DIFF
--- a/scripts/resume-pdf/generate.ts
+++ b/scripts/resume-pdf/generate.ts
@@ -582,11 +582,16 @@ async function build(): Promise<{ bytes: Uint8Array; pageCount: number }> {
 
   // Metadata strings go through the same normalize + encode gate as on-page
   // text, so a stray non-WinAnsi char in the name can't silently bypass it.
-  const metaTitle = normalizeForPdf(`${resume.name} — ${resume.title}`);
+  // Window/tab title: the name + role joined with underscores (no extension), e.g.
+  // "Tanel_Treuberg_Software_Engineer". Paired with showInWindowTitleBar below so
+  // viewers use this instead of the "resume.pdf" filename.
+  const metaTitle = normalizeForPdf(`${resume.name} ${resume.title}`.replace(/\s+/g, '_'));
   const metaAuthor = normalizeForPdf(resume.name);
   assertEncodable(metaTitle, fonts.regular, 'meta.title');
   assertEncodable(metaAuthor, fonts.regular, 'meta.author');
-  doc.setTitle(metaTitle);
+  // showInWindowTitleBar sets the ViewerPreferences /DisplayDocTitle flag so viewers
+  // use /Title for the window/tab title instead of the filename (defaults to false).
+  doc.setTitle(metaTitle, { showInWindowTitleBar: true });
   doc.setAuthor(metaAuthor);
   doc.setSubject('Resume');
   doc.setCreator('resume-pdf generator');


### PR DESCRIPTION
## Summary
`doc.setTitle(metaTitle)` was missing `{ showInWindowTitleBar: true }`, so the PDF's ViewerPreferences `/DisplayDocTitle` defaulted to **false** — meaning viewers kept showing the `resume.pdf` **filename** in the window/tab title instead of `/Title`. (Thanks to the reviewer for catching this.)

- Set `setTitle(metaTitle, { showInWindowTitleBar: true })` → `/DisplayDocTitle true`.
- Set `/Title` to the name+role underscored: **`Tanel_Treuberg_Software_Engineer`** (no extension), so the inline-preview tab reads that.

## Verification
- [x] `pdfinfo` Title = `Tanel_Treuberg_Software_Engineer`
- [x] pdf-lib inspection: `ViewerPreferences /DisplayDocTitle = true`
- [x] `npm run check` / `resume:pdf` / `resume:pdf:verify` pass, 1 A4 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)