### PR TITLE
Resume: serve PDF as Tanel_Treuberg_Software_Engineer.pdf so downloads are named

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ pnpm-debug.log*
 dist/
 .astro/
 
-# Build-time generated resume PDF (dev convenience copy; CI writes dist/resume.pdf)
-public/resume.pdf
+# Build-time generated resume PDF (dev convenience copy; CI writes it into dist/)
+public/Tanel_Treuberg_Software_Engineer.pdf
 
 # IDE / editor
 .vscode/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run build` — Production build into `dist/`
 - `npm run check` — TypeScript + Astro diagnostics (`astro check`); the project's only static-analysis gate
 - `npm run preview` — Preview the production build locally
-- `npm run resume:pdf` — Generate `dist/resume.pdf` directly from `src/data/resume.ts` via `pdf-lib` (no browser; see Deployment → Resume PDF). Add `-- --copy-public` to also write the gitignored `public/resume.pdf` so the dev-server Export button resolves.
+- `npm run resume:pdf` — Generate `dist/Tanel_Treuberg_Software_Engineer.pdf` directly from `src/data/resume.ts` via `pdf-lib` (no browser; see Deployment → Resume PDF). Add `-- --copy-public` to also write the gitignored `public/Tanel_Treuberg_Software_Engineer.pdf` so the dev-server Export button resolves.
 - `npm run resume:pdf:verify` — Poppler gate (`pdfinfo` + `pdftotext`) asserting the generated PDF is A4 and its text extracts in reading order. Needs `poppler-utils` installed.
 
 There is no automated test suite. Verification on changes is `npm run check` + `npm run build` + manual browser checks. Do not claim "tests pass" — say so explicitly when verification is build-only.
@@ -27,13 +27,13 @@ Precedent: the bento card morph-jump ("expands right, then jumps to center", Saf
 
 ### Resume PDF (build-time, ATS-minimal, deterministic)
 
-- `/resume.pdf` is generated at **build time**, not committed. It is a **bare-minimum, machine-readable (ATS) document built directly from `src/data/resume.ts`** — NOT a render of the styled `/resume/` page. [scripts/resume-pdf/generate.ts](scripts/resume-pdf/generate.ts) (run via `tsx`) lays out a single-column, black-&-white A4 page with `pdf-lib` using the **base-14 Helvetica family (non-embedded)** → ~5 KB, fully copyable text, clickable `/Link` annotations (email + portfolio). The "Export PDF" button is a static `<a href="/resume.pdf" download>`.
+- The PDF is generated at **build time**, not committed, and served at **`/Tanel_Treuberg_Software_Engineer.pdf`** (the filename doubles as the download name since GitHub Pages can't set `Content-Disposition`; `PDF_FILENAME` in [generate.ts](scripts/resume-pdf/generate.ts) is the source of truth — keep the button href, robots.txt, .gitignore and verify script in sync with it). It is a **bare-minimum, machine-readable (ATS) document built directly from `src/data/resume.ts`** — NOT a render of the styled `/resume/` page. `generate.ts` (run via `tsx`) lays out a single-column, black-&-white A4 page with `pdf-lib` using the **base-14 Helvetica family (non-embedded)** → ~5 KB, fully copyable text, clickable `/Link` annotations (email + portfolio). The **View PDF** button is `<a href="/Tanel_Treuberg_Software_Engineer.pdf" target="_blank">` (opens an inline preview, not a forced download). The PDF's `/Title` + `DisplayDocTitle` make viewers show that name (sans `.pdf`) in the tab.
 - **No headless browser.** Chromium/Playwright/sirv were intentionally removed — `page.pdf()` always embeds font subsets (heavy) and risks ATS reading-order scrambling. Direct generation gives zero embedded fonts and clean linear text order.
 - **Character policy:** [scripts/resume-pdf/sanitize.ts](scripts/resume-pdf/sanitize.ts) preserves all WinAnsi-renderable characters (Estonian letters `OÜ`/`INSÜK`, `°`, `×`, `·`, dashes, smart quotes) and normalizes only the genuinely non-renderable superscripts (`10⁻³` → `10^-3`). Every drawn string passes `normalizeForPdf` then `assertEncodable` (`font.encodeText`), which **throws (fails the build) on any un-encodable char** — never ships a silent "?".
 - **Determinism:** no `Date.now()`/`Math.random()`; metadata dates derive from `resume.meta.updatedAt` (fixed UTC). Two runs produce byte-identical output. Single page is a soft target — the generator `console.warn`s (does not hard-fail) if content overflows to a 2nd page; tighten layout constants in `generate.ts` or trim content if so.
 - **CI gate:** [scripts/verify-resume-pdf.mjs](scripts/verify-resume-pdf.mjs) runs poppler `pdfinfo` (A4 + page count) + `pdftotext` (key text present and in reading order) and fails the build on any miss.
 - **Self-hosted fonts** ([src/styles/fonts.css](src/styles/fonts.css), woff2 in `public/fonts/`; no Google Fonts CDN) remain — they serve the live **website** only; the PDF does not use them.
-- `/resume/` and `/resume.pdf` are disallowed in [public/robots.txt](public/robots.txt) (the page is also `noindex`; GitHub Pages can't set `X-Robots-Tag` on the static PDF).
+- `/resume/` and the PDF are disallowed in [public/robots.txt](public/robots.txt) (the page is also `noindex`; GitHub Pages can't set `X-Robots-Tag` on the static PDF).
 
 ## Liquid Glass Nav Module
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow: /resume/
-Disallow: /resume.pdf
+Disallow: /Tanel_Treuberg_Software_Engineer.pdf

--- a/scripts/resume-pdf/generate.ts
+++ b/scripts/resume-pdf/generate.ts
@@ -5,8 +5,8 @@
 // deterministic: fixed metadata, fixed creation/mod dates derived from
 // resume.meta.updatedAt, no Date.now()/Math.random().
 //
-// Run: `npm run resume:pdf` (writes dist/resume.pdf). Pass `--copy-public` to
-// also write public/resume.pdf.
+// Run: `npm run resume:pdf` (writes dist/<PDF_FILENAME>). Pass `--copy-public` to
+// also write public/<PDF_FILENAME>.
 
 import { mkdir, writeFile, copyFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -36,6 +36,11 @@ const CONTENT_BOTTOM = MARGIN; // y must stay above this
 
 const BLACK = rgb(0, 0, 0);
 const RULE = rgb(0, 0, 0); // black divider under section headers
+
+// Output filename. On GitHub Pages this also becomes the download filename (no
+// Content-Disposition is possible), so it's named after the person rather than
+// "resume.pdf". Must match the button href, robots.txt, .gitignore and verify script.
+const PDF_FILENAME = 'Tanel_Treuberg_Software_Engineer.pdf';
 
 // Type scale
 const SIZE_NAME = 18;
@@ -584,7 +589,7 @@ async function build(): Promise<{ bytes: Uint8Array; pageCount: number }> {
   // text, so a stray non-WinAnsi char in the name can't silently bypass it.
   // Window/tab title: the name + role joined with underscores (no extension), e.g.
   // "Tanel_Treuberg_Software_Engineer". Paired with showInWindowTitleBar below so
-  // viewers use this instead of the "resume.pdf" filename.
+  // viewers use this (without the .pdf) instead of the URL filename.
   const metaTitle = normalizeForPdf(`${resume.name} ${resume.title}`.replace(/\s+/g, '_'));
   const metaAuthor = normalizeForPdf(resume.name);
   assertEncodable(metaTitle, fonts.regular, 'meta.title');
@@ -851,7 +856,10 @@ async function main(): Promise<void> {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const repoRoot = path.resolve(here, '..', '..');
   const distDir = path.join(repoRoot, 'dist');
-  const outPath = path.join(distDir, 'resume.pdf');
+  // The served filename IS the download name on GitHub Pages (no Content-Disposition
+  // header is possible), so name it after the person, not "resume.pdf". Keep this in
+  // sync with the button href, robots.txt, .gitignore and verify script.
+  const outPath = path.join(distDir, PDF_FILENAME);
 
   const { bytes, pageCount } = await build();
 
@@ -868,13 +876,13 @@ async function main(): Promise<void> {
   }
 
   if (process.argv.includes('--copy-public')) {
-    const publicPath = path.join(repoRoot, 'public', 'resume.pdf');
+    const publicPath = path.join(repoRoot, 'public', PDF_FILENAME);
     await mkdir(path.dirname(publicPath), { recursive: true });
     await copyFile(outPath, publicPath);
-    console.log(`✓ resume-pdf: also copied → public/resume.pdf`);
+    console.log(`✓ resume-pdf: also copied → public/${PDF_FILENAME}`);
   }
 
-  console.log(`✓ resume-pdf: ${pageCount} page(s) → dist/resume.pdf`);
+  console.log(`✓ resume-pdf: ${pageCount} page(s) → dist/${PDF_FILENAME}`);
 }
 
 main().catch((err) => {

--- a/scripts/verify-resume-pdf.mjs
+++ b/scripts/verify-resume-pdf.mjs
@@ -1,4 +1,4 @@
-// Machine-readability gate for dist/resume.pdf, using poppler (pdfinfo + pdftotext).
+// Machine-readability gate for dist/Tanel_Treuberg_Software_Engineer.pdf, using poppler (pdfinfo + pdftotext).
 // Asserts the PDF is A4, has selectable text, and that key content extracts in the
 // correct reading order. Exits non-zero (fails CI) on any miss. Run AFTER the generator.
 import { execFileSync } from 'node:child_process';
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const ROOT = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
-const PDF = path.join(ROOT, 'dist', 'resume.pdf');
+const PDF = path.join(ROOT, 'dist', 'Tanel_Treuberg_Software_Engineer.pdf');
 
 // Substrings that must be present, in this extraction order (reading order).
 const ORDERED = ['Tanel', 'EXPERIENCE', 'EDUCATION', 'SKILLS'];

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -19,7 +19,7 @@ import { resume } from '../data/resume';
     <header class="resume-toolbar">
       <ResumeModeToggle defaultMode="interactive" />
       <a
-        href="/resume.pdf"
+        href="/Tanel_Treuberg_Software_Engineer.pdf"
         target="_blank"
         rel="noopener"
         class="resume-print-btn"


### PR DESCRIPTION
## Summary
GitHub Pages can't set `Content-Disposition`, so a file's **URL name is its download name**. To make exporting save as the person's name (instead of `resume.pdf`) while keeping the inline preview, the served PDF is renamed:

- Output: `dist/resume.pdf` → **`dist/Tanel_Treuberg_Software_Engineer.pdf`** (`PDF_FILENAME` constant in `generate.ts` is the source of truth).
- Updated to match: View PDF button `href`, `public/robots.txt`, `.gitignore`, `scripts/verify-resume-pdf.mjs`, and `CLAUDE.md`.
- Behavior unchanged otherwise: opens inline (preview); downloading from the viewer now saves `Tanel_Treuberg_Software_Engineer.pdf`.

## Test plan
- [x] `npm run check` / `build` / `resume:pdf` / `resume:pdf:verify`
- [x] `dist/Tanel_Treuberg_Software_Engineer.pdf` emitted; built button href points to it; no stale `/resume.pdf` refs
- [ ] CI deploy ships it; View PDF previews, download saves the named file

🤖 Generated with [Claude Code](https://claude.com/claude-code)