### PR TITLE
chore(resume-pdf): blank Creator/Producer in the PDF Info dict

### DIFF
--- a/scripts/resume-pdf/generate.ts
+++ b/scripts/resume-pdf/generate.ts
@@ -592,8 +592,10 @@ async function build(): Promise<{ bytes: Uint8Array; pageCount: number }> {
   doc.setTitle(metaTitle, { showInWindowTitleBar: true });
   doc.setAuthor(metaAuthor);
   doc.setSubject('Resume');
-  doc.setCreator('resume-pdf generator');
-  doc.setProducer('pdf-lib');
+  // Blank Creator/Producer so the Info dict advertises no authoring tooling.
+  // (Leaving them unset would make pdf-lib fall back to its own default strings.)
+  doc.setCreator('');
+  doc.setProducer('');
   doc.setCreationDate(fixedDate);
   doc.setModificationDate(fixedDate);
 


### PR DESCRIPTION
## Summary
Sets `/Creator` and `/Producer` to empty strings in the generated resume PDF's Info dictionary, so it advertises no authoring tooling.

### Why not just remove the setters?
Leaving them unset is **not** equivalent — pdf-lib then falls back to its own default strings (e.g. `pdf-lib (https://github.com/Hopding/pdf-lib)`), which is longer and *more* tool-advertising. Setting them to `''` is the reliable way to drop them.

### Result
```
Creator:   (empty)
Producer:  (empty)
```
- Output stays deterministic (fixed dates from `resume.meta.updatedAt`, no `Date.now()`).
- Minor size drop: 5,814 → 5,778 bytes.

### Verification
- `npm run resume:pdf` → 1 page
- `npm run resume:pdf:verify` → A4, text extractable in reading order

🤖 Generated with [Claude Code](https://claude.com/claude-code)