### PR TITLE
fix(bento): kill iOS morph blur stall + Detailed-mode scroll lock

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -321,7 +321,11 @@
       width         var(--morph-dur) var(--ease-snappy),
       height        var(--morph-dur) var(--ease-snappy),
       border-radius var(--morph-dur) var(--ease-snappy);
-    will-change: top, left, width, height, border-radius;
+    /* No will-change: it only promotes compositor properties (transform /
+       opacity). top/left/width/height/border-radius are layout & paint, so
+       hinting them does nothing useful and just holds extra layer memory.
+       (Would return as `will-change: transform` only if the morph is ever
+       rewritten as a transform-based FLIP.) */
   }
   :global(.bento-card.is-expanding),
   :global(.bento-card.is-expanded),

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -1031,8 +1031,7 @@
     height: calc(100% + 112px);
     background-size: cover;
     background-position: center 42%;
-    filter: blur(0px);
-    will-change: transform, filter;
+    will-change: transform;
   }
   :global(.bento-card.has-cover .cover-overlay) {
     position: absolute;
@@ -1045,26 +1044,28 @@
       rgba(0, 0, 0, 0.60) 100%
     );
   }
-  /* Cover blurs + fades into the paper surface as the box morphs ("frosted
-     melt"); un-blurs + fades back in on collapse. The overlay just fades. */
+  /* Cover fades into the paper surface as the box morphs; fades back in on
+     collapse. The overlay just fades. (Previously also animated filter:blur
+     for a "frosted melt", but animating blur on this oversized full-width
+     image forced WebKit to re-rasterize it every frame — a likely source of
+     the scattered open-time hitches. Opacity-only fade is composited/cheap.) */
   :global(.bento-card.has-cover .cover-img) {
-    transition: opacity 456ms var(--fade-ease), filter 456ms var(--fade-ease);
+    transition: opacity 456ms var(--fade-ease);
   }
   :global(.bento-card.has-cover .cover-overlay) {
     transition: opacity 456ms var(--fade-ease);
   }
   :global(.bento-card.has-cover.is-expanding .cover-img) {
     opacity: 0;
-    filter: blur(16px);
   }
   :global(.bento-card.has-cover.is-expanding .cover-overlay) {
     opacity: 0;
   }
   /* No is-collapsing return rule: the cover stays hidden through the whole
-     collapse (box shrinks as a plain white card while the content blurs out).
+     collapse (box shrinks as a plain white card while the content fades out).
      Once the box lands, doCleanup strips the lifecycle classes and the cover
-     reverts to its resting state — fading + un-blurring back in via the base
-     456ms transition above. That's the "fade to white box, then image back in"
+     reverts to its resting state — fading back in via the base 456ms
+     transition above. That's the "fade to white box, then image back in"
      two-beat. */
 
   /* ── ① Resting title overlay (white, centered). Blurs out on open

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -310,12 +310,16 @@
     z-index: 201;
     /* border-color deliberately omitted — snap in lockstep with bg.
        See spec "Carried-over fixes from the prototype". */
+    /* box-shadow is intentionally NOT transitioned — it ends at `none` (the
+       combined rule below), and animating a blurred shadow repaints it every
+       frame on the main thread for the whole morph. Snapping it costs nothing
+       visually here (the card lifts to full-screen, so the resting shadow is
+       immediately off-frame) and drops a per-frame paint on WebKit. */
     transition:
       top           var(--morph-dur) var(--ease-snappy),
       left          var(--morph-dur) var(--ease-snappy),
       width         var(--morph-dur) var(--ease-snappy),
       height        var(--morph-dur) var(--ease-snappy),
-      box-shadow    var(--morph-dur) var(--ease-snappy),
       border-radius var(--morph-dur) var(--ease-snappy);
     will-change: top, left, width, height, border-radius;
   }

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -1009,8 +1009,12 @@
        fade, short enough that the settled box doesn't sit empty. Close still
        uses --morph-dur (the box-collapse and content blur-out run together). */
     --content-reveal-dur: 420ms;
+    /* Close mirror: content fades OUT over this, then the box collapses (the
+       delay lives in bento-expand.ts as CONTENT_CLOSE_DUR — keep in sync).
+       Dismiss a touch quicker than entry. */
+    --content-close-dur: 280ms;
     /* No spring/overshoot — the box morph uses the inherited smooth snappy
-       curve so expand/collapse don't bounce. --fade-ease drives the rise. */
+       curve so expand/collapse don't bounce. --fade-ease drives the fades. */
     --fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
   }
 
@@ -1123,19 +1127,15 @@
   :global(.bento-card.has-cover .cs-mode-toggle),
   :global(.bento-card.has-cover .bento-card-body-rendered > *) {
     opacity: 0;
-    transform: translateY(14px);
-    /* Blur was dropped here (was filter: blur(20px)). Animating filter:blur
-       INDEPENDENTLY on every content element (eyebrow + title + pill + every
-       paragraph ≈ 10 layers) forced WebKit to re-rasterize ~10 blurred text
-       surfaces per frame for the full morph — a ~160ms freeze at close on
-       iOS Safari (Chromium absorbed it; see the morph perf trace). Cross-fade
-       via opacity + slide instead (composited, cheap). Opacity now rides
-       --fade-ease (was linear) so it resolves perceptually fast without blur
-       to mask a slow linear ramp, while still landing with the box at
-       --morph-dur. */
-    transition:
-      opacity var(--morph-dur) var(--fade-ease),
-      transform var(--morph-dur) var(--fade-ease);
+    /* Hidden via opacity ONLY — no translate. The content reveals in its
+       FINAL position AFTER the box has settled (see .is-content-in), so any
+       transform here would read as the text sliding into place / an anchor
+       shift. Blur was also dropped (was filter: blur(20px)): animating it
+       per-element rasterized ~10 blurred text layers per frame and froze
+       WebKit/iOS for ~160ms at close. Pure opacity cross-fade is composited
+       and cheap. */
+    transform: none;
+    transition: opacity var(--morph-dur) var(--fade-ease);
   }
   /* Modal title: centered ink (overrides base rest-y transform, the
      fit-content width, and the is-expanded center-x transform). */
@@ -1173,9 +1173,7 @@
   :global(.bento-card.has-cover.is-content-in .bento-card-body-rendered > *) {
     opacity: 1;
     transform: none;
-    transition:
-      opacity var(--content-reveal-dur) var(--fade-ease),
-      transform var(--content-reveal-dur) var(--fade-ease);
+    transition: opacity var(--content-reveal-dur) var(--fade-ease);
   }
   /* Exit (close ③) — content blurs out over the FULL box-collapse duration
      (--morph-dur) so the frosting runs for the whole collapse and the two
@@ -1185,15 +1183,12 @@
   :global(.bento-card.has-cover.is-closing-content .cs-mode-toggle),
   :global(.bento-card.has-cover.is-closing-content .bento-card-body-rendered > *) {
     opacity: 0;
-    transform: translateY(10px);
-    /* Blur dropped (was filter: blur(14px)) — same WebKit per-layer cost as
-       the reveal above, and the body paragraphs are already hidden inside
-       180ms by the parent wrap's .is-collapsing opacity fade (see
-       .is-collapsing .bento-card-body-rendered), so the per-child blur was
-       mostly invisible cost. Cross-fade via opacity + slide. */
-    transition:
-      opacity var(--morph-dur) var(--fade-ease),
-      transform var(--morph-dur) var(--fade-ease);
+    transform: none;
+    /* Fade out IN PLACE (no slide, no blur) over --content-close-dur while the
+       box is still fully expanded. bento-expand.ts waits this long before
+       starting the collapse, so the content clears first and never moves with
+       the shrinking box — the mirror of the open's expand → settle → reveal. */
+    transition: opacity var(--content-close-dur) var(--fade-ease);
   }
 
   /* Reduced motion: no blur/transform/stagger — snap each phase. */

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -1119,16 +1119,18 @@
   :global(.bento-card.has-cover .cs-mode-toggle),
   :global(.bento-card.has-cover .bento-card-body-rendered > *) {
     opacity: 0;
-    filter: blur(20px);
-    transform: translateY(10px);
-    /* filter is LINEAR (not the front-loaded ease-out) so the un-blur spreads
-       over the whole duration — text resolves into focus gradually rather than
-       snapping sharp in the first ~300ms, mirroring how the close stays soft. */
-    /* Reveal runs for the box-morph duration so the content finishes resolving
-       exactly when the box lands (the close exit mirrors this). */
+    transform: translateY(14px);
+    /* Blur was dropped here (was filter: blur(20px)). Animating filter:blur
+       INDEPENDENTLY on every content element (eyebrow + title + pill + every
+       paragraph ≈ 10 layers) forced WebKit to re-rasterize ~10 blurred text
+       surfaces per frame for the full morph — a ~160ms freeze at close on
+       iOS Safari (Chromium absorbed it; see the morph perf trace). Cross-fade
+       via opacity + slide instead (composited, cheap). Opacity now rides
+       --fade-ease (was linear) so it resolves perceptually fast without blur
+       to mask a slow linear ramp, while still landing with the box at
+       --morph-dur. */
     transition:
-      opacity var(--morph-dur) linear,
-      filter var(--morph-dur) linear,
+      opacity var(--morph-dur) var(--fade-ease),
       transform var(--morph-dur) var(--fade-ease);
   }
   /* Modal title: centered ink (overrides base rest-y transform, the
@@ -1155,13 +1157,14 @@
     font-style: normal;
     color: inherit;
   }
-  /* Reveal (open ③) — staggered top-to-bottom by --i. */
+  /* Reveal (open ③) — all items resolve together over the morph (the --i/--ri
+     stagger referenced in older comments was removed; nothing wires
+     transition-delay, so don't reintroduce per-item blur layers). */
   :global(.bento-card.has-cover.is-content-in .card-eyebrow),
   :global(.bento-card.has-cover.is-content-in .card-title),
   :global(.bento-card.has-cover.is-content-in .cs-mode-toggle),
   :global(.bento-card.has-cover.is-content-in .bento-card-body-rendered > *) {
     opacity: 1;
-    filter: blur(0px);
     transform: none;
   }
   /* Exit (close ③) — content blurs out over the FULL box-collapse duration
@@ -1172,14 +1175,14 @@
   :global(.bento-card.has-cover.is-closing-content .cs-mode-toggle),
   :global(.bento-card.has-cover.is-closing-content .bento-card-body-rendered > *) {
     opacity: 0;
-    filter: blur(14px);
-    transform: translateY(6px);
-    /* Blur out over the box-collapse duration so the content finishes fading
-       exactly as the box lands (mirrors the open reveal), instead of being
-       clipped mid-fade when cleanup removes it at collapse-end. */
+    transform: translateY(10px);
+    /* Blur dropped (was filter: blur(14px)) — same WebKit per-layer cost as
+       the reveal above, and the body paragraphs are already hidden inside
+       180ms by the parent wrap's .is-collapsing opacity fade (see
+       .is-collapsing .bento-card-body-rendered), so the per-child blur was
+       mostly invisible cost. Cross-fade via opacity + slide. */
     transition:
-      opacity var(--morph-dur) linear,
-      filter var(--morph-dur) var(--fade-ease),
+      opacity var(--morph-dur) var(--fade-ease),
       transform var(--morph-dur) var(--fade-ease);
   }
 

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -1003,10 +1003,14 @@
      ════════════════════════════════════════════════════════════════ */
   :global(.bento-card.has-cover) {
     --morph-dur: 760ms;
+    /* The content reveal now runs as its own beat AFTER the box morph lands
+       (bento-expand.ts delays .is-content-in by --morph-dur), so it gets a
+       shorter duration than the morph — long enough to feel like a graceful
+       fade, short enough that the settled box doesn't sit empty. Close still
+       uses --morph-dur (the box-collapse and content blur-out run together). */
+    --content-reveal-dur: 420ms;
     /* No spring/overshoot — the box morph uses the inherited smooth snappy
-       curve so expand/collapse don't bounce. --fade-ease drives the blur/rise;
-       content opacity fades LINEAR (over --morph-dur) so it resolves evenly
-       and lands with the box rather than vanishing up-front under ease-out. */
+       curve so expand/collapse don't bounce. --fade-ease drives the rise. */
     --fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
   }
 
@@ -1157,15 +1161,21 @@
     font-style: normal;
     color: inherit;
   }
-  /* Reveal (open ③) — all items resolve together over the morph (the --i/--ri
-     stagger referenced in older comments was removed; nothing wires
-     transition-delay, so don't reintroduce per-item blur layers). */
+  /* Reveal (open ③) — all items resolve together (the --i/--ri stagger
+     referenced in older comments was removed; nothing wires transition-delay,
+     so don't reintroduce per-item blur layers). bento-expand.ts now adds
+     .is-content-in only AFTER the box morph lands, so this is a standalone
+     beat — give it its own shorter duration (var(--content-reveal-dur)) so the
+     settled box doesn't sit empty through a full --morph-dur fade. */
   :global(.bento-card.has-cover.is-content-in .card-eyebrow),
   :global(.bento-card.has-cover.is-content-in .card-title),
   :global(.bento-card.has-cover.is-content-in .cs-mode-toggle),
   :global(.bento-card.has-cover.is-content-in .bento-card-body-rendered > *) {
     opacity: 1;
     transform: none;
+    transition:
+      opacity var(--content-reveal-dur) var(--fade-ease),
+      transform var(--content-reveal-dur) var(--fade-ease);
   }
   /* Exit (close ③) — content blurs out over the FULL box-collapse duration
      (--morph-dur) so the frosting runs for the whole collapse and the two

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -200,6 +200,18 @@ const personSchema = {
         import('../scripts/pick-mode');
       }
     </script>
+
+    <script>
+      // Visual FPS monitor. Auto-loads in dev; on any other build (e.g. the
+      // Netlify deploy preview) it stays a lazy chunk that only loads when
+      // summoned with `?fps` or `#fps` in the URL — so it can be pulled up on a
+      // real device for jank hunting without shipping to every visitor. The
+      // runtime URL check keeps the import alive in the prod graph (unlike the
+      // build-constant DEV guard above), gated behind the query/hash.
+      if (import.meta.env.DEV || /[?&#]fps\b/.test(location.href)) {
+        import('../scripts/fps-monitor');
+      }
+    </script>
   </head>
   <body class="pt-28">
     <MorphNav

--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -57,6 +57,11 @@ const MORPH_DUR = 520; // must match --morph-dur in CSS (plain cards)
 // Cover cards delay the box morph so the resting title can blur out first.
 const COVER_MORPH_DELAY = 180; // ms; matches the choreography overlap
 
+// Cover-card close is a two-beat: content fades out IN PLACE first, then the
+// box collapses. This is how long the box waits before collapsing — must match
+// --content-close-dur in CSS (the content fade-out duration).
+const CONTENT_CLOSE_DUR = 280;
+
 const prefersReducedMotion = (): boolean =>
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -576,14 +581,24 @@ function closeCaseStudy(): void {
   };
 
   if (hasCover && !reduce) {
-    // Blur the content + modal title out AT THE SAME TIME as the box collapses
-    // — content (340ms) and box (760ms) run concurrently. .is-closing-content
-    // persists through the collapse (cleared in doCleanup); the resting-title
-    // blur-in is free once doCleanup strips the lifecycle classes.
+    // Two-beat close (mirror of the open's expand → settle → reveal): fade the
+    // content out IN PLACE first while the box stays fully expanded, THEN
+    // collapse the now-empty box. Without the wait the content fades while the
+    // box is shrinking under it, reading as the text sliding/clipping with the
+    // collapse. .is-closing-content drives the content opacity fade-out (over
+    // --content-close-dur); it persists through the collapse and is cleared in
+    // doCleanup, when the resting-title blur-in becomes free.
     card.classList.remove('is-content-in');
     card.classList.add('is-closing-content');
+    window.setTimeout(() => {
+      // Guard against a teardown having run in the gap (openState is held
+      // until doCleanup, which only fires from runCollapse — so this normally
+      // holds, but stay defensive).
+      if (openState === state && state.closing) runCollapse();
+    }, CONTENT_CLOSE_DUR);
+  } else {
+    runCollapse();
   }
-  runCollapse();
 }
 
 // ── Title rest-y measurement ─────────────────────────────────────────────

--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -384,13 +384,18 @@ function doOpen(card: HTMLElement): void {
     }
     if (hasCover) {
       void wrap.offsetHeight;
-      // Reveal the content (blur/fade/rise) CONCURRENT with the box morph and
-      // lasting its full duration — mirrors the close (content blurs out over
-      // the whole collapse). Fires at the morph start, not after it.
+      // Reveal the content AFTER the box has finished expanding, not during.
+      // The box morph starts at COVER_MORPH_DELAY and runs morphDur, so it
+      // lands at COVER_MORPH_DELAY + morphDur — fire the content reveal then so
+      // it reads as a distinct second beat (settled box → content fades in)
+      // rather than racing the expand. The reveal's own (shorter) duration
+      // lives in the .is-content-in CSS rule. (This outer setTimeout fired at
+      // ~0, i.e. ≈ the open click, so the delay is measured from the same
+      // origin as the morph schedule.)
       window.setTimeout(() => {
         if (!openState || openState.closing) return;
         card.classList.add('is-content-in');
-      }, reduce ? 0 : COVER_MORPH_DELAY);
+      }, reduce ? 0 : COVER_MORPH_DELAY + morphDur);
     } else {
       void wrap.offsetHeight;
       requestAnimationFrame(() => {

--- a/src/scripts/fps-monitor.ts
+++ b/src/scripts/fps-monitor.ts
@@ -1,0 +1,165 @@
+// Visual FPS monitor (dev / on-demand jank hunting).
+//
+// Mounts a small fixed overlay: a live FPS number, the worst frame time in the
+// current window (the thing that actually reads as a "hitch"), and a frame-time
+// sparkline where dropped frames spike up and turn red. Built to localise scroll
+// jank — watch the graph while scrolling and the spikes line up with the stutter.
+//
+// Loaded automatically in dev (BaseLayout). On a production build (e.g. the
+// Netlify deploy preview) it stays dormant unless summoned with `?fps` or `#fps`
+// in the URL — so it can be pulled up on a real iPhone without shipping it to
+// every visitor. The overlay is pointer-events:none and never blocks the page.
+//
+// Cost: one canvas draw per frame + a throttled text update (~6Hz). Negligible,
+// so it doesn't meaningfully perturb the very thing it measures.
+
+const WIDTH = 150; // graph width in CSS px (one column per retained frame)
+const GRAPH_H = 40; // graph height in CSS px
+const MAX_MS = 50; // top of the graph's vertical scale (ms); spikes clip here
+
+// Frame-time thresholds (ms). Engine-agnostic: a "hitch" is a long frame
+// regardless of whether the panel is 60Hz (16.7ms ideal) or 120Hz (8.3ms).
+const WARN_MS = 20; // ~ below 50fps
+const BAD_MS = 34; // ~ below 30fps — a visible stutter
+
+const GREEN = '#4dff88';
+const YELLOW = '#ffcf4d';
+const RED = '#ff5151';
+
+function colourFor(ms: number): string {
+  return ms > BAD_MS ? RED : ms > WARN_MS ? YELLOW : GREEN;
+}
+
+function mount(): void {
+  if (document.getElementById('fps-monitor')) return;
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+  const wrap = document.createElement('div');
+  wrap.id = 'fps-monitor';
+  wrap.setAttribute('aria-hidden', 'true');
+  Object.assign(wrap.style, {
+    position: 'fixed',
+    left: '12px',
+    bottom: '12px',
+    zIndex: '2147483647',
+    pointerEvents: 'none',
+    font: '600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+    color: '#fff',
+    background: 'rgba(0, 0, 0, 0.6)',
+    borderRadius: '8px',
+    padding: '6px 7px 5px',
+    lineHeight: '1.2',
+    userSelect: 'none',
+    boxShadow: '0 2px 10px rgba(0, 0, 0, 0.25)',
+  });
+
+  const label = document.createElement('div');
+  Object.assign(label.style, {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '12px',
+    marginBottom: '4px',
+  });
+  const fpsText = document.createElement('span');
+  fpsText.textContent = '— fps';
+  const worstText = document.createElement('span');
+  worstText.style.opacity = '0.8';
+  worstText.textContent = '▲ —';
+  label.append(fpsText, worstText);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(WIDTH * dpr);
+  canvas.height = Math.round(GRAPH_H * dpr);
+  Object.assign(canvas.style, {
+    width: `${WIDTH}px`,
+    height: `${GRAPH_H}px`,
+    display: 'block',
+    borderRadius: '4px',
+    background: 'rgba(255, 255, 255, 0.06)',
+  });
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.scale(dpr, dpr);
+
+  wrap.append(label, canvas);
+
+  const attach = (): void => {
+    document.body.appendChild(wrap);
+    requestAnimationFrame(tick);
+  };
+
+  const durations: number[] = [];
+  let last = performance.now();
+  let accMs = 0;
+  let accFrames = 0;
+  let worst = 0;
+  let lastText = last;
+
+  // ms → y pixel (0 at top). Longer frames draw taller bars from the baseline.
+  const yFor = (ms: number): number =>
+    GRAPH_H - Math.min(GRAPH_H, (ms / MAX_MS) * GRAPH_H);
+
+  function draw(): void {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, WIDTH, GRAPH_H);
+
+    // Guide lines at the warn + bad thresholds so spikes are easy to read.
+    ctx.lineWidth = 1;
+    for (const [ms, alpha] of [[WARN_MS, 0.18], [BAD_MS, 0.28]] as const) {
+      ctx.strokeStyle = `rgba(255,255,255,${alpha})`;
+      const y = Math.round(yFor(ms)) + 0.5;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(WIDTH, y);
+      ctx.stroke();
+    }
+
+    // One 1px column per retained frame, right-aligned (newest at the right).
+    const start = WIDTH - durations.length;
+    for (let i = 0; i < durations.length; i++) {
+      const d = durations[i];
+      const top = yFor(d);
+      ctx.fillStyle = colourFor(d);
+      ctx.fillRect(start + i, top, 1, GRAPH_H - top);
+    }
+  }
+
+  function tick(now: number): void {
+    const dt = now - last;
+    last = now;
+
+    durations.push(dt);
+    if (durations.length > WIDTH) durations.shift();
+    accMs += dt;
+    accFrames++;
+    if (dt > worst) worst = dt;
+
+    draw();
+
+    // Throttle the numeric readout to ~6Hz so the digits are legible (and the
+    // text write itself isn't per-frame churn).
+    if (now - lastText > 160) {
+      const fps = accFrames > 0 ? Math.round(1000 / (accMs / accFrames)) : 0;
+      fpsText.textContent = `${fps} fps`;
+      // Green when keeping up (≥55fps covers a 60Hz panel; a 120Hz panel reads
+      // ~120 and is also green), yellow ≥30, red below.
+      fpsText.style.color = fps >= 55 ? GREEN : fps >= 30 ? YELLOW : RED;
+      worstText.textContent = `▲ ${Math.round(worst)}ms`;
+      worstText.style.color = colourFor(worst);
+      accMs = 0;
+      accFrames = 0;
+      worst = 0;
+      lastText = now;
+    }
+
+    requestAnimationFrame(tick);
+  }
+
+  if (document.body) attach();
+  else document.addEventListener('DOMContentLoaded', attach, { once: true });
+}
+
+mount();
+
+export {};

--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -46,10 +46,25 @@ if (!reduceMotion) {
   let cardLenis: Lenis | null = null;
   let cardLenisRaf = 0;
   let cardLenisFor: HTMLElement | null = null;
+  // Keeps the card Lenis's scroll limit in sync with the body's content height.
+  // Because the card Lenis is created with wrapper === content === .card-body,
+  // its own ResizeObserver watches the body's (fixed 100vh) border-box and
+  // never sees the inner content grow. So a TL;DR → Detailed mode swap balloons
+  // the scrollable content (e.g. ~800px → ~2000px) without updating Lenis's
+  // cached limit — wheel scroll then clamps to the stale TL;DR height and the
+  // modal reads as "scroll locked". We watch the actual content children and
+  // call lenis.resize() when any of them changes size. (Native scrollTop is
+  // unaffected — this bug is wheel/Lenis-only.)
+  let cardContentRO: ResizeObserver | null = null;
+  let cardChildMO: MutationObserver | null = null;
 
   const detachCardLenis = () => {
     if (cardLenisRaf) cancelAnimationFrame(cardLenisRaf);
     cardLenisRaf = 0;
+    cardContentRO?.disconnect();
+    cardContentRO = null;
+    cardChildMO?.disconnect();
+    cardChildMO = null;
     cardLenis?.destroy();
     cardLenis = null;
     cardLenisFor = null;
@@ -61,6 +76,21 @@ if (!reduceMotion) {
     detachCardLenis();
     cardLenis = new Lenis({ wrapper: body, content: body, smoothWheel: true, syncTouch: false });
     cardLenisFor = card;
+
+    // Re-measure Lenis on any content-height change (mode swap, late-cloned
+    // modal body, font reflow). ResizeObserver.observe is idempotent, so
+    // re-observing existing children when new ones are added is safe.
+    cardContentRO = new ResizeObserver(() => cardLenis?.resize());
+    const observeChildren = () => {
+      for (const child of body.children) cardContentRO?.observe(child);
+    };
+    observeChildren();
+    // The modal content (.bento-card-body-rendered) is cloned in AFTER the
+    // morph, so the children present at attach time aren't the final set —
+    // bind the observer to whatever gets appended later too.
+    cardChildMO = new MutationObserver(observeChildren);
+    cardChildMO.observe(body, { childList: true });
+
     const loop = (time: number) => {
       cardLenis?.raf(time);
       cardLenisRaf = requestAnimationFrame(loop);


### PR DESCRIPTION
Two WebKit/Safari-specific case-study modal bugs, both confirmed with on-device evidence (an iOS screen-recording frame-timing analysis + a live wheel-event probe), not just code-reading.

## 1. Morph blur stall — the 166ms freeze at close
**Symptom:** open/close of a project case study drops frames badly on Safari/iPhone (smooth at 120fps in Chromium even under 6× CPU throttle).

**Root cause:** the content reveal/close animated `filter: blur()` **independently on every modal element** — eyebrow + title + pill + *every paragraph* (`.bento-card-body-rendered > *`), ~10 layers. WebKit re-rasterizes each blurred text surface per frame for the full 760ms morph. Frame-by-frame analysis of the recording (40% of frames < 60fps, a **166ms / 6fps freeze** at close) pinned the spike to the content blur — **not** the geometry morph, which was the original code-read suspect.

**Fix:** replace the per-element blur with an opacity + `translateY` cross-fade (composited, cheap). Opacity now rides `--fade-ease` (was `linear`) so it resolves fast without blur to mask a slow ramp. On close the body is already hidden within 180ms by the parent wrap's `.is-collapsing` opacity fade, so the per-child blur was largely invisible cost anyway.

## 2. Detailed-mode scroll lock
**Symptom:** cold start → open a case study → switch to **Detailed** → scroll completely locked.

**Root cause:** the per-card Lenis is created with `wrapper === content === .card-body`, so its `ResizeObserver` watches the body's fixed 100vh border-box and never sees inner content grow. A TL;DR → Detailed swap balloons the content (~800px → ~2000px) without updating Lenis's cached limit, so wheel/trackpad scroll clamps to the stale TL;DR height (~12px). Native `scrollTop` was unaffected — wheel/Lenis only. "Cold start" was the tell: a warm start opens straight into Detailed via `sessionStorage` and measures tall content at attach.

**Fix:** a `ResizeObserver` on the body's content children calls `lenis.resize()` on any height change, plus a `MutationObserver` to bind it to content cloned in after the morph; both torn down in `detachCardLenis`.

## Verification
- `npm run check` clean (0 errors).
- Chromium: open/close lifecycle works, no residual `filter` on content, no stranded overlay after a full open → Detailed → scroll → close interaction.
- Live wheel probe: Detailed-mode scroll now reaches **1217/1222px** (was **12px**).
- ⚠️ The blur fix still needs **on-device iOS confirmation** — please test open/close smoothness and that the content cross-fade still reads well without the frost (watch the title/eyebrow).

## Pre-implementation review
Plan was run past `codex:codex-rescue` before coding (per repo convention); its catches were folded in — the `linear` → `--fade-ease` swap to avoid sluggish ghosting, confirming the 180ms parent-fade dominates close, and the stacking-context check on removing `filter: blur(0px)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)