### PR TITLE
fix(parallax): stop section headings shimmering during scroll

### DIFF
--- a/src/scripts/scroll-parallax.ts
+++ b/src/scripts/scroll-parallax.ts
@@ -125,7 +125,14 @@ function update(): void {
       const y = active ? -progress * layer.depth * RANGE : 0;
       if (Math.abs(y - layer.lastY) < MIN_DELTA) continue;
       layer.lastY = y;
-      layer.el.style.transform = y ? `translate3d(0, ${y}px, 0)` : '';
+      // Always write translate3d — even at y=0 (translate3d(0,0,0)) — rather
+      // than clearing to ''. Clearing demotes the compositor layer; the next
+      // non-zero offset re-promotes it. That promote/demote churn at every
+      // viewport-center crossing re-rasterizes the layer and flips its text
+      // between subpixel- and grayscale-AA, reading as a shimmer. Holding a
+      // 3d transform keeps the layer promoted and stable. (Paired with
+      // will-change:transform in CSS so it's promoted from first paint too.)
+      layer.el.style.transform = `translate3d(0, ${y}px, 0)`;
     }
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -488,6 +488,20 @@ body.bento-open .nav-progressive-blur {
   transform: none;
 }
 
+/* Parallax depth layers animate `transform` on scroll. Promote them up front so
+   the compositor layer stays stable. Without this, scroll-parallax.ts toggling
+   the transform demotes/re-promotes the layer at each viewport-center crossing,
+   which re-rasterizes it and flips the heading text between subpixel- and
+   grayscale-AA — a visible shimmer in the page body. (Hero layers + .cover-img
+   already promote via their own will-change; this covers the section heading
+   layers.) Scoped to motion: parallax is disabled under reduced-motion, so
+   there's nothing to stabilise and no reason to hold the layers. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-parallax] [data-depth] {
+    will-change: transform;
+  }
+}
+
 /* Full-bleed hero must not introduce horizontal scroll. The site hides
    scrollbars, which would otherwise MASK overflow instead of preventing it. */
 html,


### PR DESCRIPTION
The body glitch you spotted on scroll. The section heading layers — the `data-depth` divs wrapping each `<h2>` in About / Projects / Skills / Contact — are parallaxed, but unlike the hero layers and `.cover-img` they had **no `will-change`**, and [scroll-parallax.ts](src/scripts/scroll-parallax.ts) cleared their transform to `''` whenever a section centered in the viewport.

Together that **demotes then re-promotes** the compositor layer at every center-crossing → re-rasterizes it and flips the serif heading between **subpixel- and grayscale-AA** → a visible shimmer (plus the re-raster dips). Hero/covers were fine precisely because they already `will-change: transform`.

## Fix
- **scroll-parallax.ts:** always write `translate3d(0, y, 0)` (even at `y=0`) instead of clearing to `''` — the layer never demotes mid-scroll.
- **global.css:** `will-change: transform` on `[data-parallax] [data-depth]` so the layers are promoted from first paint (consistent AA from the start). Scoped to `(prefers-reduced-motion: no-preference)` — parallax is off under reduced-motion, so there's nothing to stabilize and no reason to hold the layers there.

## Trade
The headings render with grayscale-AA consistently (instead of flipping). Imperceptible on Retina/high-DPI; on a low-DPI external monitor the serif headings may look a hair softer at rest — the standard trade for killing the shimmer.

## Verification
Chromium: the section layers keep a `translate3d` transform across a center-crossing scroll (never `''`) and report `will-change: transform`. **On-device confirmation pending** — I couldn't reproduce the shimmer reliably on my Chromium, so please confirm the headings stop shimmering while scrolling (and that they still look crisp at rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)