### PR TITLE
docs(ideas): add animation/UI-craft vocabulary references

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -28,6 +28,9 @@
 
 ### Design
 - https://emilkowal.ski/ui/7-practical-animation-tips
+- https://animations.dev/vocabulary
+- https://www.ui-skills.com · [repo](https://github.com/ibelick/ui-skills)
+- https://index.how/to/articulate
 - https://pixelwrld.co
 - https://godly.website/website/roman-tesliuk-947
 - https://mchiu.co.uk


### PR DESCRIPTION
Adds three design-craft / vocabulary resources to the **Design** section of `docs/ideas/Ideas.md`, grouped with the existing Emil Kowalski animation-tips entry:

- `animations.dev/vocabulary` (Kowalski — animation vocabulary)
- `ui-skills.com` + [`ibelick/ui-skills`](https://github.com/ibelick/ui-skills) repo
- `index.how/to/articulate`

Docs-only; not part of the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)