### PR TITLE
fix: nav inert+visibility for old WebKit a11y; body min-height → dvh

### DIFF
--- a/src/components/MorphNav.astro
+++ b/src/components/MorphNav.astro
@@ -323,21 +323,30 @@ const heroId = sections[0]?.id ?? "hero";
     opacity: 0;
     filter: blur(10px);
     pointer-events: none;
+    /* visibility:hidden removes the collapsed panel's links from the tab order
+       and a11y tree cross-browser — the `inert` property (set in JS) no-ops on
+       iOS < 15.5, so opacity/pointer-events alone would leave them reachable
+       there. Hidden is delayed until the fade-out finishes so the close isn't
+       cut; shown immediately on open (see .is-open). */
+    visibility: hidden;
     transition:
       opacity 300ms cubic-bezier(.5, 0, .88, .77),
-      filter 300ms cubic-bezier(.5, 0, .88, .77);
+      filter 300ms cubic-bezier(.5, 0, .88, .77),
+      visibility 0s linear 300ms;
   }
 
   .morph-nav.is-open .morph-body {
     opacity: 1;
     filter: blur(0);
     pointer-events: auto;
+    visibility: visible;
     /* On open, de-blur on the same 1000ms curve as the shell's height expansion
        so the blur finishes exactly as the last item is fully revealed (opacity
        still fades in quickly). The base 300ms transition governs the close. */
     transition:
       opacity 300ms cubic-bezier(.5, 0, .88, .77),
-      filter 1000ms cubic-bezier(.44, 0, .08, 1);
+      filter 1000ms cubic-bezier(.44, 0, .08, 1),
+      visibility 0s;
   }
 
   /* Vertical nav list: each item is its own rounded clickable area. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,7 +96,11 @@ body {
   transition: background-color 0.3s ease, color 0.3s ease;
   position: relative;
   isolation: isolate;
-  min-height: 100vh;
+  /* dvh tracks the iOS toolbar rather than locking to the large viewport.
+     Build floor is Safari 16.1 (Tailwind/Lightning CSS target), which supports
+     dvh, so no vh fallback is needed — Lightning strips duplicate-prop
+     fallbacks at this target anyway. */
+  min-height: 100dvh;
   /* Suppress double-tap-to-zoom (and the legacy ~300ms tap delay) page-wide so
      the site behaves like a native app. `manipulation` still permits normal
      scrolling; pinch-zoom is blocked separately (viewport meta on Android,


### PR DESCRIPTION
Acts on the cross-browser audit's safe-fix batch. One item was attempted then reverted — see note.

## Changes

**MorphNav `inert` a11y gap (iOS < 15.5)** — [MorphNav.astro](src/components/MorphNav.astro)
`HTMLElement.inert` (set in JS when the panel is collapsed) no-ops on iOS < 15.5, so the closed nav's links stayed in the tab order / a11y tree on old WebKit (`opacity:0`/`pointer-events:none` don't remove them). Paired `inert` with `visibility:hidden`, which removes them cross-browser. Hidden is delayed past the 300ms fade-out (`transition: visibility 0s linear 300ms`) so the close animation isn't cut, and shown immediately on open. `visibility:hidden` keeps layout, so `measure()`'s `scrollHeight` read is unaffected.

**`body` min-height → `100dvh`** — [global.css](src/styles/global.css)
Tracks the iOS toolbar instead of locking to the large viewport. Correctness hygiene (largely inert on a long page).

## Reverted: oklch fallback

An sRGB hex fallback for the `--accent` `oklch()` tokens was attempted and **reverted**. Tailwind v4's Lightning CSS pass targets Safari 16.1 (where `oklch` is supported) and **strips duplicate-property fallbacks at build time** — confirmed in `dist`: `--accent` ships as bare `oklch(...)`. So the fallback never reaches the browser; shipping it would be dead source implying safety it doesn't provide. Within the 16.1 build floor `oklch` needs no fallback. A real sub-15.4 fallback would require lowering the CSS build target — a separate, larger decision.

## Verification
- `astro check` → 0 errors / 0 warnings
- `npm run build` → passes; confirmed `min-height:100dvh` and `visibility` in shipped `dist` CSS
- Build-only. **The nav open/close animation timing (visibility delay) wants a quick on-device check**, especially iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)