### PR TITLE
perf: trim bento edge blur 5→3 backdrop-filter layers

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -556,69 +556,46 @@
      up window the filter "pops" at the start of the transition. */
   :global(.card-blur.is-on) { opacity: 1; }
 
-  /* TOP strip — heaviest blur at y=0 (edge), fades toward interior. */
+  /* TOP strip — heaviest blur at y=0 (edge), fades toward interior.
+     3 feathered layers (was 5): interior → mid → edge. */
   :global(.card-blur-top > div:nth-child(1)) {
-    -webkit-backdrop-filter: blur(0.5px);
-    backdrop-filter: blur(0.5px);
-    -webkit-mask-image: linear-gradient(to bottom, black 0 80%, transparent 100%);
-    mask-image: linear-gradient(to bottom, black 0 80%, transparent 100%);
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+    -webkit-mask-image: linear-gradient(to bottom, black 0 66%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 0 66%, transparent 100%);
   }
   :global(.card-blur-top > div:nth-child(2)) {
-    -webkit-backdrop-filter: blur(1.5px);
-    backdrop-filter: blur(1.5px);
-    -webkit-mask-image: linear-gradient(to bottom, black 0 60%, transparent 80%);
-    mask-image: linear-gradient(to bottom, black 0 60%, transparent 80%);
-  }
-  :global(.card-blur-top > div:nth-child(3)) {
-    -webkit-backdrop-filter: blur(3px);
-    backdrop-filter: blur(3px);
-    -webkit-mask-image: linear-gradient(to bottom, black 0 40%, transparent 60%);
-    mask-image: linear-gradient(to bottom, black 0 40%, transparent 60%);
-  }
-  :global(.card-blur-top > div:nth-child(4)) {
     -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
-    -webkit-mask-image: linear-gradient(to bottom, black 0 20%, transparent 40%);
-    mask-image: linear-gradient(to bottom, black 0 20%, transparent 40%);
+    -webkit-mask-image: linear-gradient(to bottom, black 0 33%, transparent 70%);
+    mask-image: linear-gradient(to bottom, black 0 33%, transparent 70%);
   }
-  :global(.card-blur-top > div:nth-child(5)) {
+  :global(.card-blur-top > div:nth-child(3)) {
     -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
-    -webkit-mask-image: linear-gradient(to bottom, black 0 5%, transparent 20%);
-    mask-image: linear-gradient(to bottom, black 0 5%, transparent 20%);
+    -webkit-mask-image: linear-gradient(to bottom, black 0 8%, transparent 36%);
+    mask-image: linear-gradient(to bottom, black 0 8%, transparent 36%);
   }
 
   /* BOTTOM strip — same radii, gradient direction flipped so blur is
      heaviest at the bottom edge and fades upward. */
   :global(.card-blur-bottom > div:nth-child(1)) {
-    -webkit-backdrop-filter: blur(0.5px);
-    backdrop-filter: blur(0.5px);
-    -webkit-mask-image: linear-gradient(to top, black 0 80%, transparent 100%);
-    mask-image: linear-gradient(to top, black 0 80%, transparent 100%);
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+    -webkit-mask-image: linear-gradient(to top, black 0 66%, transparent 100%);
+    mask-image: linear-gradient(to top, black 0 66%, transparent 100%);
   }
   :global(.card-blur-bottom > div:nth-child(2)) {
-    -webkit-backdrop-filter: blur(1.5px);
-    backdrop-filter: blur(1.5px);
-    -webkit-mask-image: linear-gradient(to top, black 0 60%, transparent 80%);
-    mask-image: linear-gradient(to top, black 0 60%, transparent 80%);
-  }
-  :global(.card-blur-bottom > div:nth-child(3)) {
-    -webkit-backdrop-filter: blur(3px);
-    backdrop-filter: blur(3px);
-    -webkit-mask-image: linear-gradient(to top, black 0 40%, transparent 60%);
-    mask-image: linear-gradient(to top, black 0 40%, transparent 60%);
-  }
-  :global(.card-blur-bottom > div:nth-child(4)) {
     -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
-    -webkit-mask-image: linear-gradient(to top, black 0 20%, transparent 40%);
-    mask-image: linear-gradient(to top, black 0 20%, transparent 40%);
+    -webkit-mask-image: linear-gradient(to top, black 0 33%, transparent 70%);
+    mask-image: linear-gradient(to top, black 0 33%, transparent 70%);
   }
-  :global(.card-blur-bottom > div:nth-child(5)) {
+  :global(.card-blur-bottom > div:nth-child(3)) {
     -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
-    -webkit-mask-image: linear-gradient(to top, black 0 5%, transparent 20%);
-    mask-image: linear-gradient(to top, black 0 5%, transparent 20%);
+    -webkit-mask-image: linear-gradient(to top, black 0 8%, transparent 36%);
+    mask-image: linear-gradient(to top, black 0 8%, transparent 36%);
   }
 
   @media (max-width: 540px) {

--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -50,7 +50,7 @@ function makeBlurStrip(position: 'top' | 'bottom'): HTMLElement {
   const strip = document.createElement('div');
   strip.className = `card-blur card-blur-${position}`;
   strip.setAttribute('aria-hidden', 'true');
-  for (let i = 0; i < 5; i++) strip.appendChild(document.createElement('div'));
+  for (let i = 0; i < 3; i++) strip.appendChild(document.createElement('div'));
   return strip;
 }
 


### PR DESCRIPTION
Second half of the perf pass (#5). Visually-confirmed near-identical, 40% cheaper.

## Why
The expanded case-study modal renders an Apple-style **progressive blur** at its top and bottom edges. There's no native variable-radius blur in any engine, so it's built from **stacked masked `backdrop-filter` layers** — and it used **5 per edge = 10 backdrop-filter passes**, the heaviest paint on an open card and the costliest on WebKit.

## What
Reduce to **3 feathered layers per edge** (6 passes, **−40%**):
- Keep the heavy **12px** edge radius that carries the frosted-edge look.
- Re-tune to radii **2 / 6 / 12px** with feathered masks so the interior→edge ramp stays smooth.
- Drop the two sub-2px layers (0.5/1.5px) — they were near-invisible.

Strips are mounted on open and removed on close, so this is **only ever live on an open modal** — zero cost at rest.

## Verification
- `astro check` → 0 errors / 0 warnings; `npm run build` → passes.
- **Same-scroll Chromium A/B** (expanded "Detailed" case study, scrollTop 420, identical content): the 3-layer result is **visually near-indistinguishable** from 5 layers — no banding, smooth ramp at both edges — running at 120fps. Verified by screenshot comparison.
- Chromium only; the win is WebKit paint cost, which can't be measured in this environment, but the change strictly reduces backdrop-filter passes.

## Context
Per the audit, this was the "needs profiling to justify" item. Profiling showed no problem in Chromium (120fps with the full 10-layer stack), so this ships as a **safe, visually-validated reduction** rather than a fix for observed jank — it lowers the WebKit ceiling at no perceptible visual cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)