### PR TITLE
fix: remove bento card hover lift (instant translateY jump)

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -75,7 +75,9 @@
   }
 
   :global(.bento-card:hover) {
-    transform: translateY(-2px);
+    /* Shadow-only hover (no translateY lift): the base transition animates
+       box-shadow but not transform, so the lift snapped instantly and read
+       as a jump. Deepening the shadow gives the hover cue without moving. */
     box-shadow:
       0 6px 24px rgba(0, 0, 0, 0.06),
       0 2px 6px rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
## Symptom
The bento cards visibly **shift/jump** on hover.

## Cause
`.bento-card:hover` applied `transform: translateY(-2px)`, but the card's base transition only animates `box-shadow` (not `transform`) — so the 2px lift snapped **instantly, un-eased**, reading as a jarring jump rather than a smooth lift.

## Fix
Remove the `translateY` lift. Keep the box-shadow deepen (which *is* transitioned), so hover still gives an elevation cue without moving the card.

## Verification
- `astro check` → 0 errors; `npm run build` → passes.
- Build-only; the no-jump hover is visible on the deploy preview.

Note: kept a subtle shadow-on-hover. Say the word if you'd prefer a fully static hover (no shadow change either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)