### PR TITLE
chore: WebKit-parity hygiene — backdrop-filter prefix gate + teardown note

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "dev:lan": "astro dev --host",
     "start": "astro dev",
+    "prebuild": "node scripts/check-css-prefixes.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "check": "astro check && npm run check:content",
+    "check": "astro check && npm run check:content && npm run check:css",
     "check:content": "node scripts/check-content.mjs",
+    "check:css": "node scripts/check-css-prefixes.mjs",
     "resume:pdf": "tsx scripts/resume-pdf/generate.ts",
     "resume:pdf:verify": "node scripts/verify-resume-pdf.mjs"
   },

--- a/scripts/check-css-prefixes.mjs
+++ b/scripts/check-css-prefixes.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Fails the build when a `backdrop-filter` declaration is missing its
-// `-webkit-backdrop-filter` twin (or vice-versa) within the same rule.
+// `-webkit-backdrop-filter` twin (or vice-versa) WITHIN THE SAME RULE / SCOPE.
 //
 // Why this exists: there is NO autoprefixer in the pipeline. Tailwind v4's
 // Lightning CSS pass only prefixes what's in its target matrix, and Astro's
@@ -11,8 +11,13 @@
 // fails Chrome/Firefox. This gate turns either into a hard error so the
 // Chromium↔WebKit parity floor can't regress unnoticed.
 //
-// Convention in this repo: the two declarations are always written adjacent
-// (either order), so a small ±line window is enough to find the twin.
+// It covers BOTH forms:
+//   • CSS declarations in .css / .astro <style>:   backdrop-filter: …;
+//   • runtime JS in .ts (e.g. liquid-glass.ts):     style.setProperty('backdrop-filter', …)
+//
+// Scoping is by brace nesting (the enclosing {…} block), not a line window, so
+// two unpaired declarations in *different* adjacent rules can't mask each other.
+// A tiny tokenizer ignores braces and property names inside comments/strings.
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, extname, relative } from 'node:path';
@@ -20,13 +25,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
 const SRC = join(ROOT, 'src');
-const EXTS = new Set(['.css', '.astro']); // CSS files + scoped <style> in .astro
-const WINDOW = 3; // lines to scan around a declaration for its twin
-
-// `-webkit-backdrop-filter:` …
-const WEBKIT = /-webkit-backdrop-filter\s*:/;
-// standard `backdrop-filter:` NOT preceded by `-webkit-`
-const STANDARD = /(^|[^-])backdrop-filter\s*:/;
+const EXTS = new Set(['.css', '.astro', '.ts']);
 
 function walk(dir) {
   const out = [];
@@ -38,29 +37,95 @@ function walk(dir) {
   return out;
 }
 
+// Tokenize `src`, returning backdrop-filter declarations as {line, block, kind}.
+// `block` is an id for the enclosing {…} scope; a pair counts only if both
+// halves share the same block. Braces / property tokens inside comments and
+// strings are ignored.
+function findDeclarations(src) {
+  const decls = [];
+  const stack = []; // enclosing block ids; top = current scope (0 = file top)
+  let blocks = 0;
+  let line = 1;
+  let state = 'normal'; // normal | line_comment | block_comment | string
+  let strDelim = '';
+  const curBlock = () => (stack.length ? stack[stack.length - 1] : 0);
+
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i], c2 = src[i + 1];
+    if (c === '\n') { line++; continue; }
+
+    if (state === 'line_comment') continue; // ended by the \n branch above
+    if (state === 'block_comment') { if (c === '*' && c2 === '/') { state = 'normal'; i++; } continue; }
+    if (state === 'string') {
+      if (c === '\\') { i++; continue; }
+      if (c === strDelim) state = 'normal';
+      continue;
+    }
+
+    // normal state
+    if (c === '/' && c2 === '/') { state = 'line_comment'; i++; continue; }
+    if (c === '/' && c2 === '*') { state = 'block_comment'; i++; continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      // capture the string body and classify if it's a backdrop-filter prop name
+      const delim = c; let j = i + 1; let body = '';
+      while (j < src.length && src[j] !== delim) {
+        if (src[j] === '\\') { body += src[j + 1] ?? ''; j += 2; continue; }
+        if (src[j] === '\n') line++;
+        body += src[j]; j++;
+      }
+      if (body === '-webkit-backdrop-filter') decls.push({ line, block: curBlock(), kind: 'webkit' });
+      else if (body === 'backdrop-filter') decls.push({ line, block: curBlock(), kind: 'std' });
+      i = j; // sit on the closing delim (loop ++ moves past)
+      continue;
+    }
+    if (c === '{') { stack.push(++blocks); continue; }
+    if (c === '}') { stack.pop(); continue; }
+
+    // CSS-declaration form: (-webkit-)?backdrop-filter : …
+    if (src.startsWith('-webkit-backdrop-filter', i)) {
+      let k = i + '-webkit-backdrop-filter'.length;
+      while (src[k] === ' ' || src[k] === '\t') k++;
+      if (src[k] === ':') decls.push({ line, block: curBlock(), kind: 'webkit' });
+      i += '-webkit-backdrop-filter'.length - 1;
+    } else if (src.startsWith('backdrop-filter', i) && (i === 0 || src[i - 1] !== '-')) {
+      let k = i + 'backdrop-filter'.length;
+      while (src[k] === ' ' || src[k] === '\t') k++;
+      if (src[k] === ':') decls.push({ line, block: curBlock(), kind: 'std' });
+      i += 'backdrop-filter'.length - 1;
+    }
+  }
+  return decls;
+}
+
 const problems = [];
 for (const file of walk(SRC)) {
-  const lines = readFileSync(file, 'utf8').split('\n');
-  lines.forEach((line, i) => {
-    const isWebkit = WEBKIT.test(line);
-    const isStandard = !isWebkit && STANDARD.test(line);
-    if (!isWebkit && !isStandard) return;
-    const near = lines.slice(Math.max(0, i - WINDOW), i + WINDOW + 1).join('\n');
-    const twinPresent = isWebkit ? STANDARD.test(near) : WEBKIT.test(near);
-    if (!twinPresent) {
-      const missing = isWebkit ? 'standard `backdrop-filter`' : '`-webkit-backdrop-filter`';
-      problems.push(`${relative(ROOT, file)}:${i + 1}  ${line.trim()}  → missing ${missing} twin`);
+  const decls = findDeclarations(readFileSync(file, 'utf8'));
+  if (!decls.length) continue;
+  // group by block; each block must have equal std + webkit counts
+  const byBlock = new Map();
+  for (const d of decls) {
+    const g = byBlock.get(d.block) ?? { std: [], webkit: [] };
+    g[d.kind].push(d.line);
+    byBlock.set(d.block, g);
+  }
+  for (const { std, webkit } of byBlock.values()) {
+    if (std.length === webkit.length) continue;
+    const rel = relative(ROOT, file);
+    if (std.length > webkit.length) {
+      for (const ln of std) problems.push(`${rel}:${ln}  backdrop-filter without a -webkit-backdrop-filter twin in the same rule/scope`);
+    } else {
+      for (const ln of webkit) problems.push(`${rel}:${ln}  -webkit-backdrop-filter without a standard backdrop-filter twin in the same rule/scope`);
     }
-  });
+  }
 }
 
 if (problems.length) {
   console.error('✗  backdrop-filter prefix check: unpaired declaration(s) found:\n');
   for (const p of problems) console.error('   ' + p);
   console.error(
-    '\n   Every backdrop-filter must be paired with -webkit-backdrop-filter' +
-      ' (there is no autoprefixer; an unpaired prop silently breaks Safari or Chrome).',
+    '\n   Every backdrop-filter must be paired with -webkit-backdrop-filter in the' +
+      ' same rule/scope (there is no autoprefixer; an unpaired prop silently breaks Safari or Chrome).',
   );
   process.exit(1);
 }
-console.log('✓  backdrop-filter: all declarations paired with the -webkit- prefix.');
+console.log('✓  backdrop-filter: all declarations paired with the -webkit- prefix (rule-scoped, incl. .ts).');

--- a/scripts/check-css-prefixes.mjs
+++ b/scripts/check-css-prefixes.mjs
@@ -50,11 +50,26 @@ function findDeclarations(src) {
   let strDelim = '';
   const curBlock = () => (stack.length ? stack[stack.length - 1] : 0);
 
+  // True if the string literal opening at `q` is the argument of a
+  // (set|remove)Property(...) call — i.e. an actual style-property name, not an
+  // unrelated log/config string that happens to read "backdrop-filter".
+  const isStylePropCall = (q) => {
+    let k = q - 1;
+    while (k >= 0 && /\s/.test(src[k])) k--;
+    if (src[k] !== '(') return false;
+    k--;
+    while (k >= 0 && /\s/.test(src[k])) k--;
+    let end = k;
+    while (k >= 0 && /[A-Za-z]/.test(src[k])) k--;
+    const ident = src.slice(k + 1, end + 1);
+    return ident === 'setProperty' || ident === 'removeProperty';
+  };
+
   for (let i = 0; i < src.length; i++) {
     const c = src[i], c2 = src[i + 1];
-    if (c === '\n') { line++; continue; }
+    if (c === '\n') { line++; if (state === 'line_comment') state = 'normal'; continue; }
 
-    if (state === 'line_comment') continue; // ended by the \n branch above
+    if (state === 'line_comment') continue;
     if (state === 'block_comment') { if (c === '*' && c2 === '/') { state = 'normal'; i++; } continue; }
     if (state === 'string') {
       if (c === '\\') { i++; continue; }
@@ -73,8 +88,10 @@ function findDeclarations(src) {
         if (src[j] === '\n') line++;
         body += src[j]; j++;
       }
-      if (body === '-webkit-backdrop-filter') decls.push({ line, block: curBlock(), kind: 'webkit' });
-      else if (body === 'backdrop-filter') decls.push({ line, block: curBlock(), kind: 'std' });
+      if (isStylePropCall(i)) {
+        if (body === '-webkit-backdrop-filter') decls.push({ line, block: curBlock(), kind: 'webkit' });
+        else if (body === 'backdrop-filter') decls.push({ line, block: curBlock(), kind: 'std' });
+      }
       i = j; // sit on the closing delim (loop ++ moves past)
       continue;
     }

--- a/scripts/check-css-prefixes.mjs
+++ b/scripts/check-css-prefixes.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Fails the build when a `backdrop-filter` declaration is missing its
+// `-webkit-backdrop-filter` twin (or vice-versa) within the same rule.
+//
+// Why this exists: there is NO autoprefixer in the pipeline. Tailwind v4's
+// Lightning CSS pass only prefixes what's in its target matrix, and Astro's
+// scoped-style pipeline doesn't add `-webkit-backdrop-filter` either — so the
+// Safari/iOS support of every backdrop-filter on this site is upheld by a
+// hand-written prefix pair and nothing else. A missing `-webkit-` prefix fails
+// Safari/iOS *silently* (no error, just no blur); a missing standard property
+// fails Chrome/Firefox. This gate turns either into a hard error so the
+// Chromium↔WebKit parity floor can't regress unnoticed.
+//
+// Convention in this repo: the two declarations are always written adjacent
+// (either order), so a small ±line window is enough to find the twin.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, extname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
+const SRC = join(ROOT, 'src');
+const EXTS = new Set(['.css', '.astro']); // CSS files + scoped <style> in .astro
+const WINDOW = 3; // lines to scan around a declaration for its twin
+
+// `-webkit-backdrop-filter:` …
+const WEBKIT = /-webkit-backdrop-filter\s*:/;
+// standard `backdrop-filter:` NOT preceded by `-webkit-`
+const STANDARD = /(^|[^-])backdrop-filter\s*:/;
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (EXTS.has(extname(p))) out.push(p);
+  }
+  return out;
+}
+
+const problems = [];
+for (const file of walk(SRC)) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    const isWebkit = WEBKIT.test(line);
+    const isStandard = !isWebkit && STANDARD.test(line);
+    if (!isWebkit && !isStandard) return;
+    const near = lines.slice(Math.max(0, i - WINDOW), i + WINDOW + 1).join('\n');
+    const twinPresent = isWebkit ? STANDARD.test(near) : WEBKIT.test(near);
+    if (!twinPresent) {
+      const missing = isWebkit ? 'standard `backdrop-filter`' : '`-webkit-backdrop-filter`';
+      problems.push(`${relative(ROOT, file)}:${i + 1}  ${line.trim()}  → missing ${missing} twin`);
+    }
+  });
+}
+
+if (problems.length) {
+  console.error('✗  backdrop-filter prefix check: unpaired declaration(s) found:\n');
+  for (const p of problems) console.error('   ' + p);
+  console.error(
+    '\n   Every backdrop-filter must be paired with -webkit-backdrop-filter' +
+      ' (there is no autoprefixer; an unpaired prop silently breaks Safari or Chrome).',
+  );
+  process.exit(1);
+}
+console.log('✓  backdrop-filter: all declarations paired with the -webkit- prefix.');

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -182,6 +182,11 @@ const personSchema = {
       })();
     </script>
 
+    {/* ⚠️ Before adding an Astro <ClientRouter> / view-transitions here: the
+        scripts below (and bento-expand, MorphNav) never tear down their
+        observers / rAF loops / Lenis — they rely on a full reload per
+        navigation. Client-side swaps would leak them. See the NO-TEARDOWN note
+        atop src/scripts/smooth-scroll.ts and wire astro:before-swap cleanup. */}
     <script>
       // Mounted first so Lenis drives window scroll before the scroll-coupled
       // consumers (liquid-glass, MorphNav ring/scrollspy) read it.

--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -6,8 +6,15 @@
 // getBoundingClientRect — follow the smoothed position with no changes of their
 // own.
 //
-// MPA note: every navigation is a full reload, so Lenis re-inits per page; no
-// teardown/destroy needed.
+// ⚠️ NO-TEARDOWN ASSUMPTION (load-bearing). This module — and bento-expand.ts,
+// MorphNav.astro, and liquid-glass.ts — register IntersectionObservers /
+// ResizeObservers / MutationObservers / rAF loops / Lenis instances and never
+// tear them down, because every navigation is a full page RELOAD (MPA) that
+// wipes them. This holds ONLY while the site has no Astro <ClientRouter> /
+// view-transitions. The moment client-side swaps are enabled, navigations stop
+// reloading and all of the above LEAK on every navigation (~a dozen observers +
+// rAF loops + Lenis instances accumulate). Before adding <ClientRouter>, wire
+// astro:before-swap / astro:page-load teardown for each of those consumers.
 import Lenis from 'lenis';
 
 const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;


### PR DESCRIPTION
Two zero-runtime safety nets from the cross-browser audit (#7, #8). No behavior or visual change.

## #8 — backdrop-filter prefix gate
There's **no autoprefixer** in the build (Tailwind v4's Lightning CSS only prefixes its target matrix; Astro scoped styles don't add it either), so the Safari/iOS support of every `backdrop-filter` is upheld by a **hand-written `-webkit-` pair and nothing else**. Add a missing prefix and it breaks Safari *silently*.

- New `scripts/check-css-prefixes.mjs`, wired into `npm run check` as `check:css`.
- Fails when a `backdrop-filter` declaration lacks its `-webkit-backdrop-filter` twin (or vice-versa) within the same rule.
- **Tested:** passes on the 19 current pairs; catches a deliberately-unpaired one (`MorphNav.astro:157 → missing -webkit- twin`, exit 1); passes again after restore.

## #7 — no-teardown assumption (doc only)
The scroll/nav/bento/liquid-glass scripts register IntersectionObservers / ResizeObservers / MutationObservers / rAF loops / Lenis and **never tear them down** — they rely on a full page reload per navigation (MPA). That's safe *only* without an Astro `<ClientRouter>`; enable client-side swaps and they all leak per navigation.

- Documented the load-bearing assumption atop `smooth-scroll.ts` and at the `<ClientRouter>` insertion point in `BaseLayout.astro`, with the fix-forward instruction (wire `astro:before-swap` teardown first).

## Verification
- `npm run check` → astro 0 errors, content ✓, **`backdrop-filter: all declarations paired` ✓**.
- `npm run build` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)