### PR TITLE
perf: pre-mount edge blur strips during the morph (no reveal pause)

### DIFF
--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -212,6 +212,23 @@ function doOpen(card: HTMLElement): void {
   //      so there's no lost affordance.
   // Guarded on openState identity (card) so a stale callback after a close +
   // re-open can't mount chrome onto the wrong lifecycle.
+  // Create the edge blur strips at opacity:0 (idempotent). Called early —
+  // during the morph, from mountContent — so the GPU rasterizes the filter
+  // layers over the morph frames (cheap: the backdrop is paper, content still
+  // hidden) and they're WARM by the reveal. Pre-mounting both removes the
+  // create/warm-up pause at reveal time and removes the first-raster "pop"
+  // (the strips already exist and are painted before .is-on fades them in).
+  const ensureBlurStrips = (): void => {
+    if (!openState || openState.closing || openState.card !== card) return;
+    if (openState.blurTop) return; // already mounted
+    const blurTop = makeBlurStrip('top');
+    const blurBottom = makeBlurStrip('bottom');
+    card.appendChild(blurTop);
+    card.appendChild(blurBottom);
+    openState.blurTop = blurTop;
+    openState.blurBottom = blurBottom;
+  };
+
   const mountChrome = (): void => {
     if (!openState || openState.closing || openState.card !== card) return;
     if (openState.closeBtn) return; // idempotent
@@ -228,26 +245,13 @@ function doOpen(card: HTMLElement): void {
     card.appendChild(closeBtn);
     openState.closeBtn = closeBtn;
 
-    const blurTop = makeBlurStrip('top');
-    const blurBottom = makeBlurStrip('bottom');
-    card.appendChild(blurTop);
-    card.appendChild(blurBottom);
-    openState.blurTop = blurTop;
-    openState.blurBottom = blurBottom;
-
-    // Double-rAF before flipping .is-on so the browser fully paints the
-    // backdrop-filter layers at opacity:0 first. Without the warm-up frame the
-    // GPU rasterizes the filter as the opacity transition starts and the blur
-    // visibly "pops" instead of fading. (Verified no desktop hitch when dropped,
-    // but it's cheap insurance against the first-raster pop on mobile WebKit; the
-    // perceived pre-blur "pause" is the curve's slow start, not these frames.)
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (!openState || openState.closing || openState.card !== card) return;
-        blurTop.classList.add('is-on');
-        blurBottom.classList.add('is-on');
-      });
-    });
+    // Strips are pre-mounted during the morph (ensureBlurStrips in mountContent);
+    // this is a fallback for any path that skipped it. Flip .is-on in the SAME
+    // frame as .is-content-in so the blur fades in lockstep with the content —
+    // no warm-up pause, because the pre-mounted strips are already painted.
+    ensureBlurStrips();
+    openState.blurTop?.classList.add('is-on');
+    openState.blurBottom?.classList.add('is-on');
   };
 
   card.classList.add('is-expanding');
@@ -422,6 +426,12 @@ function doOpen(card: HTMLElement): void {
     for (const child of wrap.children) {
       (child as HTMLElement).classList.add('body-para');
     }
+
+    // Pre-mount the edge blur strips NOW (mid-morph, content still hidden) so the
+    // backdrop-filter layers are rasterized/warm by the reveal — then mountChrome
+    // only has to flip .is-on, in lockstep with the content fade, with no pause.
+    ensureBlurStrips();
+
     if (hasCover) {
       void wrap.offsetHeight;
       // Reveal the content AFTER the box has finished expanding, not during —


### PR DESCRIPTION
## Symptom
On opening a case study there was a **pause before the top/bottom blur lines appeared** — they showed a beat *after* the content.

## Cause
The strips were *created* at the reveal (morph end), then a double-rAF warm-up painted them before fading. So at reveal time we paid: create 12 nodes + set up backdrop-filter compositing + warm-up paint → the blur lagged the content.

## Fix
Split create-and-warm (early) from flip-on (at reveal):
- `ensureBlurStrips()` creates the strips at `opacity:0` **mid-morph** (from `mountContent`, while content is still hidden), so the GPU rasterizes the filter layers across the morph frames. This is cheap — the backdrop is just **paper** at that point (no detailed content to blur, so it's *not* the WebKit morph-jank case).
- By the reveal they're warm; `mountChrome` only flips `.is-on`, **in the same frame as `.is-content-in`**.

Result: blur fades in lockstep with the content, **no create/warm-up pause**, and no first-raster pop (the strips already exist). On WebKit (where the opacity fade snaps) this also means the blur is ready and shows *with* the content instead of lagging.

## Measured (Chromium, warm open)
- Strips in DOM at **~207ms** (was ~959ms).
- `.is-on` fires **0ms** after the content fade (was ~150ms later).
- **0 frames >24ms** during the morph — the pre-mount adds no dip (paper backdrop is cheap to blur). The one 116ms frame on the very first open was dev-server cold-start; gone on a warm open.

## Verification
- `astro check` 0 errors; `npm run build` passes.
- Open/close + content render at 120fps in Chromium.
- **On-device note:** the pre-mount sets up backdrop-filter compositing *during* the morph; cheap on desktop (paper backdrop), but worth a glance on a real iPhone to confirm no mobile-WebKit hitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)