### PR TITLE
Revert blur fade to original (420ms ease-out)

### DIFF
--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -539,16 +539,12 @@
     z-index: 2;
     pointer-events: none;
     opacity: 0;
-    /* Slow, even grow-in, started in lockstep with the content fade. The
-       strips mount at the reveal (when .is-content-in lands), so with no
-       delay the blur eases in alongside the content rather than as a late,
-       separate beat. The near-symmetric ease-in-out (slow start, no early
-       rush) replaced an earlier strong ease-out that front-loaded the
-       opacity (~85% in ~125ms) and read as a pop. Perf: this whole fade
-       lives AFTER the box-morph geometry settles, so the backdrop-filter
-       never re-rasterizes against a resizing box (the WebKit morph-jank
-       case) — only against the (cheap, compositor) content opacity fade. */
-    transition: opacity 720ms cubic-bezier(0.4, 0, 0.2, 1);
+    /* Gentle ease-out (not --ease-snappy's strong S-curve) so the fade
+       is perceptually smooth rather than popping near the midpoint.
+       Slight delay lets the card morph start visibly before the blur
+       begins fading in, so the two animations are sequenced rather
+       than fighting for attention. */
+    transition: opacity 420ms cubic-bezier(0.22, 1, 0.36, 1) 120ms;
   }
   :global(.bento-card.is-collapsing .card-blur) {
     /* On close, fade out quickly with no delay so the blur clears

--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -238,9 +238,7 @@ function doOpen(card: HTMLElement): void {
     // Double-rAF before flipping .is-on so the browser fully paints the
     // backdrop-filter layers at opacity:0 first. Without the warm-up frame the
     // GPU rasterizes the filter as the opacity transition starts and the blur
-    // visibly "pops" instead of fading. (Verified no desktop hitch when dropped,
-    // but it's cheap insurance against the first-raster pop on mobile WebKit; the
-    // perceived pre-blur "pause" is the curve's slow start, not these frames.)
+    // visibly "pops" instead of fading.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         if (!openState || openState.closing || openState.card !== card) return;


### PR DESCRIPTION
Reverts the 720ms gentle blur fade-in (#70) back to the **original** behaviour.

## Why
The 720ms `cubic-bezier(0.4,0,0.2,1)` ease-in-out (with its gentle slow-start) read as the blur **"taking a moment to load"** on open. After iterating (slow fade → pre-mount), the call is to go back to the original snappier appearance and stop tuning the blur timing.

## What
- Restores `transition: opacity 420ms cubic-bezier(0.22, 1, 0.36, 1) 120ms` on `.card-blur` (the original ease-out + 120ms delay) and the original warm-up comment.
- Pure revert of `f78e91f` — no other behaviour touched. The unmerged pre-mount experiment (#72) was already closed.

## Verification
- `astro check` 0 errors; `npm run build` passes (incl. the backdrop-filter gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)