### PR TITLE
docs(ideas): add progressive-blur reference to Glass section

### DIFF
--- a/docs/ideas/Ideas.md
+++ b/docs/ideas/Ideas.md
@@ -67,6 +67,7 @@
 ### Glass
 - https://themagicianscode.dev/prototypes/liquid-glass-pill/
 - https://kube.io/blog/liquid-glass-css-svg/
+- [Progressive blur (Paco Coursey)](https://paco.me/craft/blur) — stacked masked `backdrop-filter` layers (the technique already used by the `.card-blur` edge strips). Also documents the Chromium bug where `overflow: hidden` + `border-radius` + `backdrop-filter` clip before filtering (hard edge) — fix is to clip with `mask` instead of `overflow: hidden`. Relevant again if the expanded cards ever keep rounded corners (currently they morph to `border-radius: 0`, which sidesteps it).
 
 ## Prompting
 - https://thariqs.github.io/html-effectiveness/


### PR DESCRIPTION
## What

Adds Paco Coursey's [progressive blur](https://paco.me/craft/blur) writeup to the `### Glass` section of `docs/ideas/Ideas.md`.

## Why

The article describes the stacked-masked-`backdrop-filter`-layers technique we already ship for the expanded-card edge frost (`.card-blur` strips in `BentoGrid.astro`), and it documents the Chromium `overflow: hidden` + `border-radius` + `backdrop-filter` clipping-order bug. We don't hit that bug today because the expanded modal morphs to `border-radius: 0` while the strips are live — but we used to have a rounded-corner clipping issue, so banking the reference (and its `mask`-instead-of-`overflow` fix) is worth it for if/when the cards keep rounded corners.

Docs-only; not built into `dist/`, no site impact.

https://claude.ai/code/session_01XD9GQaQarQyy82QaejQ9Ba

---
_Generated by [Claude Code](https://claude.ai/code/session_01XD9GQaQarQyy82QaejQ9Ba)_