### PR TITLE
Reset expanded project scroll to top on every open

### DIFF
--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -362,6 +362,16 @@ function doOpen(card: HTMLElement): void {
     openState.appendedBodyWrap = wrap;
     openState.pillToggle = pillToggle;
 
+    // Reset the scroll container to the top on every open. .card-body is a
+    // persistent element (only its appended content is cloned/removed per
+    // lifecycle), so its scrollTop survives a close → reopen: scroll down,
+    // close, reopen, and the case study would re-open mid-scroll with the
+    // eyebrow stranded under the top progressive-blur band. The close-time
+    // reset (parent.scrollTop = 0 in doCleanup) only fires inside the
+    // disabled sticky-header branch, so it never runs — pin it here once the
+    // fresh content is in place so every open starts at the true top.
+    body.scrollTop = 0;
+
     // STICKY HEADER DISABLED — eyebrow + title + pill flow as normal
     // scroll content (their natural positions inside .card-body) and
     // scroll with the body. Keeping the code commented intentionally so

--- a/src/scripts/bento-expand.ts
+++ b/src/scripts/bento-expand.ts
@@ -541,6 +541,14 @@ function closeCaseStudy(): void {
       if (eyebrow) parent.insertBefore(eyebrow, stickyHeader);
       if (title) parent.insertBefore(title, stickyHeader);
       stickyHeader.remove();
+      // NOTE: this scrollTop reset is dead while the sticky header is disabled
+      // (stickyHeader is always null, so this branch never runs). It is NOT the
+      // reset that keeps every open starting at the top — that lives in
+      // mountContent (`body.scrollTop = 0`), which fires once the fresh content
+      // is mounted and the container is actually scrollable. Resetting here
+      // (at cleanup, after the scrollable content has already been removed)
+      // would be a no-op the browser can later undo via scroll restoration.
+      // Kept for if/when the sticky header is re-enabled.
       parent.scrollTop = 0;
     }
 


### PR DESCRIPTION
## Problem

Reopening a project case study did **not** reset its scroll position:

- **Cold open:** scroll starts at the top ✅
- **Scroll down → close → reopen:** the case study reopened *mid-scroll*, leaving the "CASE STUDY" eyebrow stranded under the top progressive-blur band (it reads as the blur "appearing on the content").

## Root cause

`.card-body` is the scroll container, and it's a **persistent element** — only its appended content is cloned on open and removed on close, so its `scrollTop` survives a close → reopen.

The one intended reset, `parent.scrollTop = 0` in `doCleanup` (`bento-expand.ts:534`), lives *inside* the `if (stickyHeader && stickyHeader.parentElement)` branch. The sticky header is disabled (commented out, `bento-expand.ts:365-402`), so `stickyHeader` is always `null` and that reset never fires.

## Fix

Pin `body.scrollTop = 0` right after the fresh content mounts in `mountContent`, so every open starts at the true top regardless of the prior scroll position. One-line behavioral change plus an explaining comment.

## Verification

- `npm run check` — 0 errors, 0 warnings (the single pre-existing hint in `scripts/resume-pdf/generate.ts` is unrelated)
- `npm run build` — clean, 7 pages built

Manual browser confirmation of the open/close/reopen scroll-reset is still worth a look on the deploy preview (Safari + Chrome, the two engines where the bug was reported).

https://claude.ai/code/session_018SxG3YYVqHJSj5CPoME2pg

---
_Generated by [Claude Code](https://claude.ai/code/session_018SxG3YYVqHJSj5CPoME2pg)_