### PR TITLE
ci: notify profile repo on logo changes

### DIFF
--- a/.github/workflows/notify-profile-logos.yml
+++ b/.github/workflows/notify-profile-logos.yml
@@ -1,0 +1,22 @@
+name: Notify profile of logo changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/assets/logos/**"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch logos-changed to profile repo
+        env:
+          TOKEN: ${{ secrets.PROFILE_DISPATCH_TOKEN }}
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/The-Magicians-Code/The-Magicians-Code/dispatches \
+            -d '{"event_type":"logos-changed"}'


### PR DESCRIPTION
## What

Adds `.github/workflows/notify-profile-logos.yml`, based on the [`notify-profile-logos.example.yml`](https://github.com/The-Magicians-Code/The-Magicians-Code/blob/main/docs/notify-profile-logos.example.yml) template from the profile repo.

## What it does

When a push to `main` touches anything under `src/assets/logos/**`, this workflow sends a `repository_dispatch` event (`event_type: logos-changed`) to `The-Magicians-Code/The-Magicians-Code`. That lets the profile repo regenerate its README logo grid automatically whenever the tech-stack logos here change — no manual sync needed.

It only fires on the logos path, so ordinary pushes don't trigger it.

## ⚠️ Required before it works

This workflow needs a repository secret named **`PROFILE_DISPATCH_TOKEN`** (Settings → Secrets and variables → Actions). It must be a token with **`contents: write`** permission on `The-Magicians-Code/The-Magicians-Code` — a fine-grained PAT scoped to that repo, or the profile repo could expose a token. Cross-repo dispatch can't use the default `GITHUB_TOKEN`, which is scoped to this repo only.

Until that secret exists, the `curl` step will fail (auth) on logo-path pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHj6NmQPQn7J7wLjC6xFvi)_