### PR TITLE
perf: fix Lighthouse NO_FCP — un-gate the page paint from JS-ready

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,27 +63,28 @@ const personSchema = {
     <link rel="preload" href="/fonts/geist-latin-wght-normal.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/geist-mono-latin-wght-normal.woff2" as="font" type="font/woff2" crossorigin />
 
-    {/* Hide the page until it's styled + settled, then fade in — kills the cold-load
-        flash of unstyled / not-yet-positioned content. Render-blocking inline so it
-        applies before any other CSS or paint; the themed <html> background still
-        shows (a calm colour, not blank). Revealed by the script below on
-        fonts.ready + 2 frames; the 1s CSS animation + 1s JS timeout are the
-        no-JS / failure safety nets so it can never stay hidden. Kept short
-        because the latin fonts are font-display:optional (no swap reflow to
-        wait out), so the only thing the gate masks now is the first JS
-        layout/parallax pass — a couple of frames, not seconds. */}
+    {/* Reveal gate — scoped to the bento CARDS only, not the whole page.
+        The rest of the document (hero, nav, headings, footer, project pages)
+        paints immediately, in place, with no opacity gate — so FCP comes from
+        the hero's true first paint. Only the bento cards are held back, because
+        their at-rest title position is JS-measured AFTER layout (the centered
+        title is a measured translateY; see syncTitleRestY in bento-expand.ts),
+        so painting them before that measurement would flash a top→center jump.
+        opacity (not display) keeps each card's layout box reserved → no CLS.
+        Revealed by the is-ready script below on fonts.ready + 2 frames; the 1s
+        animation / 1s JS timeout are the no-JS / failure safety nets so a card
+        can never stay hidden. One-shot animation (not a lingering transition)
+        so nothing interferes with the card's morph opacity rules. */}
     <style is:inline>
-      body { opacity: 0; animation: site-reveal 0.4s ease 1s forwards; }
-      html.is-ready body { opacity: 1; animation: none; transition: opacity 0.4s ease; }
-      @keyframes site-reveal { to { opacity: 1; } }
+      [data-bento-card] { opacity: 0; animation: bento-reveal 0.4s ease 1s forwards; }
+      html.is-ready [data-bento-card] { animation: bento-reveal 0.4s ease forwards; }
+      @keyframes bento-reveal { from { opacity: 0; } to { opacity: 1; } }
       @media (prefers-reduced-motion: reduce) {
-        /* Reduced motion: keep hide-until-ready (opacity gating isn't motion, so
-           it still prevents the FOUC) but never fade — reveal is an instant
-           opacity flip in both paths. The JS path flips via .is-ready with no
-           transition; the no-JS failsafe flips at the same 2.5s safety mark with
-           a ~0s animation (not a shortened fade). */
-        body { animation: site-reveal 0.01s linear 1s forwards; }
-        html.is-ready body { transition: none; }
+        /* Reduced motion: keep hide-until-measured (opacity gating isn't motion,
+           so it still prevents the title-jump FOUC) but never fade — reveal is
+           an instant opacity flip in both the JS and the 1s failsafe paths. */
+        [data-bento-card] { animation: bento-reveal 0.01s linear 1s forwards; }
+        html.is-ready [data-bento-card] { animation: bento-reveal 0.01s linear forwards; }
       }
     </style>
 
@@ -163,10 +164,12 @@ const personSchema = {
     </script>
 
     <script is:inline>
-      // Reveal the page (see the hide style above) once it's styled + the layout
-      // has settled: on document.fonts.ready (the font-swap reflow + bento-title
-      // positioning gate) plus two frames so the first parallax/layout pass has
-      // run. Hard 1s timeout so a slow/failed font load never blocks paint.
+      // Reveal the bento cards (see the scoped hide style above) once the
+      // bento-title positioning pass can have run: on document.fonts.ready
+      // (syncTitleRestY measures with the real serif metrics) plus two frames
+      // so that measurement has applied. The rest of the page is NOT gated and
+      // has already painted. Hard 1s timeout so a slow/failed font load never
+      // leaves the cards hidden.
       (function () {
         var revealed = false;
         function reveal() {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -67,10 +67,13 @@ const personSchema = {
         flash of unstyled / not-yet-positioned content. Render-blocking inline so it
         applies before any other CSS or paint; the themed <html> background still
         shows (a calm colour, not blank). Revealed by the script below on
-        fonts.ready + 2 frames; the 2.5s CSS animation + 1.8s JS timeout are the
-        no-JS / failure safety nets so it can never stay hidden. */}
+        fonts.ready + 2 frames; the 1s CSS animation + 1s JS timeout are the
+        no-JS / failure safety nets so it can never stay hidden. Kept short
+        because the latin fonts are font-display:optional (no swap reflow to
+        wait out), so the only thing the gate masks now is the first JS
+        layout/parallax pass — a couple of frames, not seconds. */}
     <style is:inline>
-      body { opacity: 0; animation: site-reveal 0.4s ease 2.5s forwards; }
+      body { opacity: 0; animation: site-reveal 0.4s ease 1s forwards; }
       html.is-ready body { opacity: 1; animation: none; transition: opacity 0.4s ease; }
       @keyframes site-reveal { to { opacity: 1; } }
       @media (prefers-reduced-motion: reduce) {
@@ -79,7 +82,7 @@ const personSchema = {
            opacity flip in both paths. The JS path flips via .is-ready with no
            transition; the no-JS failsafe flips at the same 2.5s safety mark with
            a ~0s animation (not a shortened fade). */
-        body { animation: site-reveal 0.01s linear 2.5s forwards; }
+        body { animation: site-reveal 0.01s linear 1s forwards; }
         html.is-ready body { transition: none; }
       }
     </style>
@@ -163,7 +166,7 @@ const personSchema = {
       // Reveal the page (see the hide style above) once it's styled + the layout
       // has settled: on document.fonts.ready (the font-swap reflow + bento-title
       // positioning gate) plus two frames so the first parallax/layout pass has
-      // run. Hard 1.8s timeout so a slow/failed font load never blocks paint.
+      // run. Hard 1s timeout so a slow/failed font load never blocks paint.
       (function () {
         var revealed = false;
         function reveal() {
@@ -178,7 +181,7 @@ const personSchema = {
           if (document.fonts && document.fonts.ready) document.fonts.ready.then(settle, reveal);
           else settle();
         } catch (_) { reveal(); }
-        setTimeout(reveal, 1800);
+        setTimeout(reveal, 1000);
       })();
     </script>
 

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -15,13 +15,20 @@
  *
  * Each family is split across latin + latin-ext subsets via unicode-range so
  * the browser only fetches the subset it needs.
+ *
+ * font-display: the primary *latin* subsets are `optional` because they are
+ * <link rel="preload">ed (see BaseLayout) — so they're in cache by first paint
+ * and the browser uses the real web font immediately, with NO fallback→web
+ * swap reflow (the CLS that the body reveal-gate used to mask). The non-
+ * preloaded latin-ext subsets stay `swap`: they cover rare accented glyphs
+ * not on the critical path, where a late swap is acceptable.
  */
 
 /* ── Fraunces (serif, opsz + wght, roman) ───────────────────────────────── */
 @font-face {
   font-family: 'Fraunces';
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
   font-weight: 100 900;
   src: url('/fonts/fraunces-latin-full-normal.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
@@ -43,7 +50,7 @@
 @font-face {
   font-family: 'Fraunces';
   font-style: italic;
-  font-display: swap;
+  font-display: optional;
   font-weight: 100 900;
   src: url('/fonts/fraunces-latin-full-italic.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
@@ -65,7 +72,7 @@
 @font-face {
   font-family: 'Geist';
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
   font-weight: 100 900;
   src: url('/fonts/geist-latin-wght-normal.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
@@ -87,7 +94,7 @@
 @font-face {
   font-family: 'Geist Mono';
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
   font-weight: 100 900;
   src: url('/fonts/geist-mono-latin-wght-normal.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,


### PR DESCRIPTION
Fixes Lighthouse **NO_FCP** ("no content was painted") and lets the page paint in place. Two related commits on the same reveal-gate topic.

## Background

`BaseLayout` held the entire `<body>` at `opacity: 0` until JS added `html.is-ready`. It existed to mask two things on cold load: (1) the `font-display: swap` fallback→web-font reflow, and (2) the bento title's **post-layout repositioning** (`syncTitleRestY` measures card height and centers the title via a measured `translateY`). Because Chrome doesn't count `opacity:0` content as a contentful paint, **FCP was gated on the whole-page reveal** → NO_FCP / a very late FCP.

## Commit 1 — kill the font-swap CLS

The preloaded **primary latin** subsets (Fraunces roman+italic, Geist, Geist Mono) switch `font-display: swap` → **`optional`**. They're `<link rel=preload>`ed, so they're cached by first paint and used immediately — **no swap reflow** (the CLS the gate masked). Non-preloaded latin-ext subsets (rare glyphs) stay `swap`.

## Commit 2 — scope the reveal gate to the bento cards only

With the font CLS gone, the only thing left to mask is the bento title measurement. So the `opacity:0` gate moves from `<body>` to **`[data-bento-card]`**:

- **Hero, nav, headings, footer, and all project detail pages now paint immediately, in place, with no opacity gate** → FCP comes from the hero's true first paint.
- Only the **bento cards** stay briefly hidden until `syncTitleRestY` has centered their titles (a measured translateY that genuinely needs post-layout geometry), then fade in on `is-ready`.
- `opacity` (not `display`) keeps each card's box reserved → **no layout shift**.
- Reveal uses a **one-shot animation** (not a lingering `transition: opacity`) so it can't interfere with the card morph's own opacity rules.
- Failsafe timers trimmed earlier (2.5s/1.8s → 1s).

**The bento morph is untouched.** Fully un-gating the cards too would require rewriting the title morph to FLIP-animate the title independently (it currently relies on a JS-measured `translateY` with a fixed flow position) — deliberately deferred; it's the system CLAUDE.md flags as historically fragile.

## ⚠️ Verify on the Netlify preview (I can't run a browser in-session)

1. **Lighthouse** — FCP is now a real, early value (no NO_FCP).
2. **No cold-load jump** — the bento titles should fade in already-centered; the rest of the page should appear instantly with nothing shifting.
3. **Card morph** — open/close a project card; the expand animation and title travel should be unchanged (incl. Safari/iOS).
4. **Fonts** — Fraunces/Geist render as web fonts on first load (with `optional`, a missed preload would fall back for that view rather than swap — rare; worth a throttled check).

## Verification done here
- `npm run check` — 0 errors (1 pre-existing unrelated hint)
- `npm run build` — succeeds; built `index.html` gates `[data-bento-card]` and has no `body{opacity:0}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)